### PR TITLE
feat: Implement Support for GCR and Extend Authentication Flexibility in goKakashi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY . .
 RUN GOARCH=amd64 go build -o goKakashi ./cmd/goKakashi.go
 
 # Stage 2: Final image for running the application with Alpine
-FROM alpine:3.18
+FROM alpine:3.20
 
 # Ensure the build fails on any command failure
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
@@ -32,10 +32,12 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN apk add --no-cache docker-cli curl bash ca-certificates
 
 # Install Trivy
-RUN curl -sfL https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_Linux-64bit.tar.gz | tar -xz -C /usr/local/bin
+RUN curl -sfL https://github.com/aquasecurity/trivy/releases/download/v0.55.1/trivy_0.55.1_Linux-64bit.tar.gz | tar -xz -C /usr/local/bin
 
 # Set working directory
 WORKDIR /app
+
+RUN mkdir -p /app/website
 
 # Copy the Go binary from the builder stage
 COPY --from=builder /app/goKakashi /app/goKakashi

--- a/cmd/goKakashi.go
+++ b/cmd/goKakashi.go
@@ -51,8 +51,8 @@ func main() {
 	cronSchedule := cron.New()
 	// Ensure cron is stopped when program exits
 	defer cronSchedule.Stop()
-	// Register cron jobs for each scan target
 
+	// Register cron jobs for each scan target
 	// Process scan targets and images
 	for _, target := range cfg.ScanTargets {
 		// Iterate over the images and scan them

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,6 +41,31 @@ scan_targets:
               issue_due_date: 2024-12-01  # YYYY-MM-DD
     scanner:
       - tool: Trivy
+  - registry: gcr
+    auth:
+      type: serviceAccount
+      json_key_path: "/path_to_.json"
+    images:
+      - name: gcr.io/ashwiniag/name
+        tags:
+          - v2.36.0
+        scan_policy:
+          severity:
+            - CRITICAL
+            - HIGH
+          notify:
+            Linear:
+              api_key: xxxx
+              project_id: 24c2aac3-638a-4824-8371-26f250fbaed1
+              team_id: e9f2cd02-7113-4ec3-bb08-ea7a151f542a
+              issue_title: TEST2
+              issue_priority: 2
+              issue_assignee_id: d74e16a8-b9e4-4fcf-a2d5-da01787f1678 # UUID of Assignee, here its ashwini@hasura.io
+              issue_state_id: 822cf3fe-a0bd-4401-9423-310c4f27d71f # UUID of Backlog, Triage, In progres etc
+              issue_due_date: 2024-12-01 #YYYY-MM-DD
+          cron_schedule: "*/1 * * * *"
+    scanner:
+      - tool: Trivy
 website:
   hostname: localhost
   files_path: /app/website  # absolute

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,8 +19,10 @@ type ScanTarget struct {
 }
 
 type Auth struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Type        string `yaml:"type"` // Types of authentication
+	Username    string `yaml:"username"`
+	Password    string `yaml:"password"`
+	JSONKeyPath string `yaml:"json_key_path"` // Optional: For GCR service account
 }
 
 type Image struct {

--- a/pkg/registry/dockerhub.go
+++ b/pkg/registry/dockerhub.go
@@ -17,7 +17,7 @@ func NewDockerHub() *DockerHub {
 
 // Login authenticates to Docker Hub using --password-stdin
 func (d *DockerHub) Login(target config.ScanTarget) error {
-	if target.Auth.Username == "" || target.Auth.Password == "" {
+	if target.Auth.Type == "basicAuth" && target.Auth.Username == "" && target.Auth.Password == "" {
 		log.Println("Skipping DockerHub login as no credentials are provided")
 		return nil
 	}

--- a/pkg/registry/gcr.go
+++ b/pkg/registry/gcr.go
@@ -1,0 +1,54 @@
+package registry
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/ashwiniag/goKakashi/pkg/config"
+)
+
+type GCR struct{}
+
+func NewGCR() *GCR {
+	return &GCR{}
+}
+
+// Login authenticates to GCR using service account JSON key
+func (g *GCR) Login(target config.ScanTarget) error {
+	if target.Auth.Type == "serviceAccount" && target.Auth.JSONKeyPath != "" {
+		log.Printf("Setting GOOGLE_APPLICATION_CREDENTIALS to %s", target.Auth.JSONKeyPath)
+		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", target.Auth.JSONKeyPath)
+
+		log.Println("Authenticating with GCR using service account...")
+
+		cmd := exec.Command("gcloud", "auth", "configure-docker")
+		output, err := cmd.CombinedOutput()
+		log.Printf("gcloud auth output: %s", string(output))
+
+		if err != nil {
+			return fmt.Errorf("GCR login failed: %v, %s", err, string(output))
+		}
+
+		log.Println("Successfully authenticated with GCR.")
+		return nil
+	}
+	return fmt.Errorf("Invalid or missing authentication method for GCR")
+}
+
+// PullImage pulls a Docker image from GCR
+func (g *GCR) PullImage(image string) error {
+	log.Printf("Pulling GCR image: %s...", image)
+
+	cmd := exec.Command("docker", "pull", image)
+	output, err := cmd.CombinedOutput()
+	log.Printf("Docker pull output: %s", string(output))
+
+	if err != nil {
+		return fmt.Errorf("docker pull failed: %v, %s", err, string(output))
+	}
+
+	log.Println("GCR image pulled successfully.")
+	return nil
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -11,8 +11,8 @@ func NewRegistry(registry string) (Registry, error) {
 		return NewDockerHub(), nil
 	//case "ecr":
 	//	return NewECR(), nil
-	//case "gcr":
-	//	return NewGCR(), nil
+	case "gcr":
+		return NewGCR(), nil
 	//case "acr":
 	//	return NewACR(), nil
 	default:


### PR DESCRIPTION
Introduces support for **Google Container Registry (GCR)** alongside flexible authentication mechanisms for container registries in the goKakashi tool. By integrating support for both basicAuth (for DockerHub) and serviceAccount (for GCR), this implementation allows goKakashi to handle a variety of authentication methods in a scalable and modular manner as the tool develops.

### Key Changes
**1. Added Support for Google Container Registry (GCR)**
We added GCR support by implementing serviceAccount authentication using a Google Cloud service account JSON key.
Why this way:
- It separates credentials from individual users, ensuring more fine-tuned access control.
- It supports non-interactive authentication, allowing the tool to run in CI/CD pipelines without depending on user logins or server-stored credentials.
- It reduces the risk of credentials being exposed or compromised.
- It’s environment-agnostic, so it works seamlessly across different setups.


### Key Design Decisions
**1.  Unified Authentication Structure with Flexibility for Growth** 
Adopted a unified structure for authentication that can support multiple methods (e.g., basicAuth, serviceAccount, and more in the future).
Why?
It ensures the tool is easy to scale i.e. is extensible and can support a wide range of authentication methods (e.g., basicAuth, serviceAccount, tokenAuth) in a consistent way without requiring significant refactoring Keeping the current implementation simple and easy to maintain.
**2. Separation of Concerns and Modularity**
This modularity ensures that the logic for each registry remains independent, making it easier to maintain and extend independently.
**3.  Config-Driven Flexibility**
The decision to have a config-driven approach for specifying authentication types (e.g., basicAuth for DockerHub, serviceAccount for GCR) makes it easy for users to switch between registries or add new registries without modifying the code. Users can define their authentication type in the config.yaml file, and goKakashi handles it appropriately based on the registry.
**4. Maintainability, Flexible and robust**