### PR TITLE
Enhance: Support Multiple Report URLs in Scan Status Response

### DIFF
--- a/pkg/api/get.go
+++ b/pkg/api/get.go
@@ -10,9 +10,9 @@ import (
 )
 
 type ScanStatusResponse struct {
-	ScanID    string `json:"scanID"`
-	Status    string `json:"status"`
-	ReportURL string `json:"report_url,omitempty"` // Optional field
+	ScanID     string   `json:"scanID"`
+	Status     string   `json:"status"`
+	ReportURLs []string `json:"report_url,omitempty"` // Optional field
 }
 
 func StatusHandler(w http.ResponseWriter, r *http.Request) {
@@ -35,8 +35,24 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	// If the status is completed, add the report URL
 	// Todo: to provide correct file path
 	if status == string(StatusCompleted) {
-		reportURL := fmt.Sprintf("http://localhost:8000/reports/%s_report.json", scanID)
-		response.ReportURL = reportURL
+		reportFilePath := fmt.Sprintf("/tmp/%s.json", scanID)
+		fileData, err := os.ReadFile(reportFilePath)
+		if err == nil {
+			var result map[string]interface{}
+			if json.Unmarshal(fileData, &result) == nil {
+				if urls, ok := result["report_urls"].([]interface{}); ok && len(urls) > 0 {
+					// Convert []interface{} to []string
+					reportURLs := make([]string, len(urls))
+					for i, url := range urls {
+						if strURL, ok := url.(string); ok {
+							reportURLs[i] = strURL
+						}
+					}
+					// Set all URLs in the response
+					response.ReportURLs = reportURLs
+				}
+			}
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/api/scan.go
+++ b/pkg/api/scan.go
@@ -129,19 +129,19 @@ func runScan(scanID string, image string, severity string, publishTarget string,
 	websiteConfig := websites[publishTarget]
 
 	// Save the scan result for future retrieval
-	saveScanStatus(scanID, string(StatusCompleted), reportFilePaths, websiteConfig.Hostname, websiteConfig.Port)
+	saveScanStatus(scanID, string(StatusCompleted), reportFilePaths, websiteConfig.ConfiguredDomain, websiteConfig.Port)
 
 	// ToDo: save the report if visibility=private|public and status=completed
 
 }
 
-func saveScanStatus(scanID, status string, reportFilePaths []string, hostname string, port int) ([]string, error) {
+func saveScanStatus(scanID, status string, reportFilePaths []string, configuredDomain string, port int) ([]string, error) {
 	resultFilePath := fmt.Sprintf("/tmp/%s.json", scanID)
 	// Build the report URLs for each saved report
 	var reportURLs []string
 	for _, filePath := range reportFilePaths {
 		// Generate the URL from hostname, port, and the file path
-		reportURL := fmt.Sprintf("http://%s:%d/reports/%s", hostname, port, filepath.Base(filePath))
+		reportURL := fmt.Sprintf("http://%s:%d/reports/%s", configuredDomain, port, filepath.Base(filePath))
 		reportURLs = append(reportURLs, reportURL)
 	}
 	// Build the scan result

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,8 +69,9 @@ type Website struct {
 	// ToDo: How do we validated the token string for each webserver, currently this is not being used
 	APIToken string `yaml:"api_token"`
 	// ToDo: define to which webserver config user wants to publish to
-	Publish      string `yaml:"visibility"`
-	ReportSubDir string `yaml:"report_sub_dir"`
+	Publish          string `yaml:"visibility"`
+	ReportSubDir     string `yaml:"report_sub_dir"`
+	ConfiguredDomain string `yaml:"configured_domain"`
 }
 
 //type PortConfig struct {


### PR DESCRIPTION
 Enhances the GET /api/v0/status/{scan_id} endpoint to support returning multiple report URLs in the scan status response. Previously, the response only returned a single URL with hardcoded values. With this update, the system now properly handles and returns all URLs generated for a scan. 
 
Benefits:
- Supports scenarios where multiple reports are generated for a single POST scan.
- Provides better visibility and flexibility for clients who need to access all reports associated with a scan. It allows user to log report_urls in their CI/CD allowing to maintain historic data of scan reports.

Example response:
```
{
  "scanID": "scan-1728361420612108000",
  "status": "completed",
  "report_urls": [
    "http://scan-reports.hasura-app.io/reports/report1.json",
    "http://scan-reports.hasura-app.io/reports/report2.json"
  ]
}
```

Websites config now looks like
```
websites:
  report_public:
    configured_domain: scan-reports.ashwiniag.com
    hostname: 0.0.0.0
    port: 8080
    report_sub_dir: public
  report_private:
    configured_domain: private-scan-reports.ashwiniag.com
    hostname: 0.0.0.0
    port: 9090
    report_sub_dir: private
```

ToDo:
- API's to take input in JSON body 
- To take multiple inputs for scanning images against field `image`