### PR TITLE
cmd: fix config flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,10 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+
+	serverConfigFilePath = serverCmd.Flags().String("config", "", "Path to the config YAML file")
 	rootCmd.AddCommand(serverCmd)
+
 	rootCmd.AddCommand(scanCmd)
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"flag"
 	"log"
 	"os"
 	"os/signal"
@@ -23,18 +22,16 @@ var serverCmd = &cobra.Command{
 	Run:   runServer,
 }
 
+var serverConfigFilePath *string
+
 func runServer(cmd *cobra.Command, args []string) {
 	log.Println("=== Starting goKakashi Tool ===")
 
-	// Get config file from command-line argument
-	configFile := flag.String("config", "", "Path to the config YAML file")
-	flag.Parse()
-
-	if *configFile == "" {
+	if *serverConfigFilePath == "" {
 		log.Fatal("Please provide the path to the config YAML file using --config")
 	}
 	// Load and validate the configuration file
-	cfg, err := config.LoadAndValidateConfig(*configFile)
+	cfg, err := config.LoadAndValidateConfig(*serverConfigFilePath)
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}


### PR DESCRIPTION
### Before
```
$ go run main.go server --config ./config/config.yaml 
Error: unknown flag: --config
Usage:
  gokakashi server [flags]

Flags:
  -h, --help   help for server

unknown flag: --config
exit status 1
```

### After
```
$ go run main.go server --config ./config/config.yaml 
2024/10/27 07:42:14 === Starting goKakashi Tool ===
2024/10/27 07:42:14 Loading configuration from YAML file: ./config/config.yaml
2024/10/27 07:42:14 Error: configuration validation failed: websites cannot be empty
exit status 1

```