### PR TITLE
api: adds CRUD operations for policy labels

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -46,6 +46,7 @@ var (
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "name", Type: field.TypeString, Unique: true},
 		{Name: "image", Type: field.TypeJSON},
+		{Name: "labels", Type: field.TypeJSON, Nullable: true},
 		{Name: "trigger", Type: field.TypeJSON, Nullable: true},
 		{Name: "check", Type: field.TypeJSON, Nullable: true},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -907,6 +907,7 @@ type PoliciesMutation struct {
 	id                   *uuid.UUID
 	name                 *string
 	image                *schema.Image
+	labels               *schema.PolicyLabels
 	trigger              *map[string]interface{}
 	check                *schema.Check
 	clearedFields        map[string]struct{}
@@ -1092,6 +1093,55 @@ func (m *PoliciesMutation) OldImage(ctx context.Context) (v schema.Image, err er
 // ResetImage resets all changes to the "image" field.
 func (m *PoliciesMutation) ResetImage() {
 	m.image = nil
+}
+
+// SetLabels sets the "labels" field.
+func (m *PoliciesMutation) SetLabels(sl schema.PolicyLabels) {
+	m.labels = &sl
+}
+
+// Labels returns the value of the "labels" field in the mutation.
+func (m *PoliciesMutation) Labels() (r schema.PolicyLabels, exists bool) {
+	v := m.labels
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLabels returns the old "labels" field's value of the Policies entity.
+// If the Policies object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PoliciesMutation) OldLabels(ctx context.Context) (v schema.PolicyLabels, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLabels is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLabels requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLabels: %w", err)
+	}
+	return oldValue.Labels, nil
+}
+
+// ClearLabels clears the value of the "labels" field.
+func (m *PoliciesMutation) ClearLabels() {
+	m.labels = nil
+	m.clearedFields[policies.FieldLabels] = struct{}{}
+}
+
+// LabelsCleared returns if the "labels" field was cleared in this mutation.
+func (m *PoliciesMutation) LabelsCleared() bool {
+	_, ok := m.clearedFields[policies.FieldLabels]
+	return ok
+}
+
+// ResetLabels resets all changes to the "labels" field.
+func (m *PoliciesMutation) ResetLabels() {
+	m.labels = nil
+	delete(m.clearedFields, policies.FieldLabels)
 }
 
 // SetTrigger sets the "trigger" field.
@@ -1280,12 +1330,15 @@ func (m *PoliciesMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PoliciesMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 5)
 	if m.name != nil {
 		fields = append(fields, policies.FieldName)
 	}
 	if m.image != nil {
 		fields = append(fields, policies.FieldImage)
+	}
+	if m.labels != nil {
+		fields = append(fields, policies.FieldLabels)
 	}
 	if m.trigger != nil {
 		fields = append(fields, policies.FieldTrigger)
@@ -1305,6 +1358,8 @@ func (m *PoliciesMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case policies.FieldImage:
 		return m.Image()
+	case policies.FieldLabels:
+		return m.Labels()
 	case policies.FieldTrigger:
 		return m.Trigger()
 	case policies.FieldCheck:
@@ -1322,6 +1377,8 @@ func (m *PoliciesMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldName(ctx)
 	case policies.FieldImage:
 		return m.OldImage(ctx)
+	case policies.FieldLabels:
+		return m.OldLabels(ctx)
 	case policies.FieldTrigger:
 		return m.OldTrigger(ctx)
 	case policies.FieldCheck:
@@ -1348,6 +1405,13 @@ func (m *PoliciesMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetImage(v)
+		return nil
+	case policies.FieldLabels:
+		v, ok := value.(schema.PolicyLabels)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLabels(v)
 		return nil
 	case policies.FieldTrigger:
 		v, ok := value.(map[string]interface{})
@@ -1393,6 +1457,9 @@ func (m *PoliciesMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *PoliciesMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(policies.FieldLabels) {
+		fields = append(fields, policies.FieldLabels)
+	}
 	if m.FieldCleared(policies.FieldTrigger) {
 		fields = append(fields, policies.FieldTrigger)
 	}
@@ -1413,6 +1480,9 @@ func (m *PoliciesMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *PoliciesMutation) ClearField(name string) error {
 	switch name {
+	case policies.FieldLabels:
+		m.ClearLabels()
+		return nil
 	case policies.FieldTrigger:
 		m.ClearTrigger()
 		return nil
@@ -1432,6 +1502,9 @@ func (m *PoliciesMutation) ResetField(name string) error {
 		return nil
 	case policies.FieldImage:
 		m.ResetImage()
+		return nil
+	case policies.FieldLabels:
+		m.ResetLabels()
 		return nil
 	case policies.FieldTrigger:
 		m.ResetTrigger()

--- a/ent/policies.go
+++ b/ent/policies.go
@@ -24,6 +24,8 @@ type Policies struct {
 	Name string `json:"name,omitempty"`
 	// Stores image details like registry, tags.
 	Image schema.Image `json:"image,omitempty"`
+	// Policies labels key:value
+	Labels schema.PolicyLabels `json:"labels,omitempty"`
 	// Stores trigger details (e.g., cron schedule).
 	Trigger map[string]interface{} `json:"trigger,omitempty"`
 	// Stores conditions for evaluation.
@@ -57,7 +59,7 @@ func (*Policies) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case policies.FieldImage, policies.FieldTrigger, policies.FieldCheck:
+		case policies.FieldImage, policies.FieldLabels, policies.FieldTrigger, policies.FieldCheck:
 			values[i] = new([]byte)
 		case policies.FieldName:
 			values[i] = new(sql.NullString)
@@ -96,6 +98,14 @@ func (po *Policies) assignValues(columns []string, values []any) error {
 			} else if value != nil && len(*value) > 0 {
 				if err := json.Unmarshal(*value, &po.Image); err != nil {
 					return fmt.Errorf("unmarshal field image: %w", err)
+				}
+			}
+		case policies.FieldLabels:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field labels", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &po.Labels); err != nil {
+					return fmt.Errorf("unmarshal field labels: %w", err)
 				}
 			}
 		case policies.FieldTrigger:
@@ -160,6 +170,9 @@ func (po *Policies) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("image=")
 	builder.WriteString(fmt.Sprintf("%v", po.Image))
+	builder.WriteString(", ")
+	builder.WriteString("labels=")
+	builder.WriteString(fmt.Sprintf("%v", po.Labels))
 	builder.WriteString(", ")
 	builder.WriteString("trigger=")
 	builder.WriteString(fmt.Sprintf("%v", po.Trigger))

--- a/ent/policies/policies.go
+++ b/ent/policies/policies.go
@@ -17,6 +17,8 @@ const (
 	FieldName = "name"
 	// FieldImage holds the string denoting the image field in the database.
 	FieldImage = "image"
+	// FieldLabels holds the string denoting the labels field in the database.
+	FieldLabels = "labels"
 	// FieldTrigger holds the string denoting the trigger field in the database.
 	FieldTrigger = "trigger"
 	// FieldCheck holds the string denoting the check field in the database.
@@ -39,6 +41,7 @@ var Columns = []string{
 	FieldID,
 	FieldName,
 	FieldImage,
+	FieldLabels,
 	FieldTrigger,
 	FieldCheck,
 }

--- a/ent/policies/where.go
+++ b/ent/policies/where.go
@@ -124,6 +124,16 @@ func NameContainsFold(v string) predicate.Policies {
 	return predicate.Policies(sql.FieldContainsFold(FieldName, v))
 }
 
+// LabelsIsNil applies the IsNil predicate on the "labels" field.
+func LabelsIsNil() predicate.Policies {
+	return predicate.Policies(sql.FieldIsNull(FieldLabels))
+}
+
+// LabelsNotNil applies the NotNil predicate on the "labels" field.
+func LabelsNotNil() predicate.Policies {
+	return predicate.Policies(sql.FieldNotNull(FieldLabels))
+}
+
 // TriggerIsNil applies the IsNil predicate on the "trigger" field.
 func TriggerIsNil() predicate.Policies {
 	return predicate.Policies(sql.FieldIsNull(FieldTrigger))

--- a/ent/policies_create.go
+++ b/ent/policies_create.go
@@ -34,6 +34,20 @@ func (pc *PoliciesCreate) SetImage(s schema.Image) *PoliciesCreate {
 	return pc
 }
 
+// SetLabels sets the "labels" field.
+func (pc *PoliciesCreate) SetLabels(sl schema.PolicyLabels) *PoliciesCreate {
+	pc.mutation.SetLabels(sl)
+	return pc
+}
+
+// SetNillableLabels sets the "labels" field if the given value is not nil.
+func (pc *PoliciesCreate) SetNillableLabels(sl *schema.PolicyLabels) *PoliciesCreate {
+	if sl != nil {
+		pc.SetLabels(*sl)
+	}
+	return pc
+}
+
 // SetTrigger sets the "trigger" field.
 func (pc *PoliciesCreate) SetTrigger(m map[string]interface{}) *PoliciesCreate {
 	pc.mutation.SetTrigger(m)
@@ -179,6 +193,10 @@ func (pc *PoliciesCreate) createSpec() (*Policies, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.Image(); ok {
 		_spec.SetField(policies.FieldImage, field.TypeJSON, value)
 		_node.Image = value
+	}
+	if value, ok := pc.mutation.Labels(); ok {
+		_spec.SetField(policies.FieldLabels, field.TypeJSON, value)
+		_node.Labels = value
 	}
 	if value, ok := pc.mutation.Trigger(); ok {
 		_spec.SetField(policies.FieldTrigger, field.TypeJSON, value)

--- a/ent/policies_update.go
+++ b/ent/policies_update.go
@@ -57,6 +57,26 @@ func (pu *PoliciesUpdate) SetNillableImage(s *schema.Image) *PoliciesUpdate {
 	return pu
 }
 
+// SetLabels sets the "labels" field.
+func (pu *PoliciesUpdate) SetLabels(sl schema.PolicyLabels) *PoliciesUpdate {
+	pu.mutation.SetLabels(sl)
+	return pu
+}
+
+// SetNillableLabels sets the "labels" field if the given value is not nil.
+func (pu *PoliciesUpdate) SetNillableLabels(sl *schema.PolicyLabels) *PoliciesUpdate {
+	if sl != nil {
+		pu.SetLabels(*sl)
+	}
+	return pu
+}
+
+// ClearLabels clears the value of the "labels" field.
+func (pu *PoliciesUpdate) ClearLabels() *PoliciesUpdate {
+	pu.mutation.ClearLabels()
+	return pu
+}
+
 // SetTrigger sets the "trigger" field.
 func (pu *PoliciesUpdate) SetTrigger(m map[string]interface{}) *PoliciesUpdate {
 	pu.mutation.SetTrigger(m)
@@ -185,6 +205,12 @@ func (pu *PoliciesUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := pu.mutation.Image(); ok {
 		_spec.SetField(policies.FieldImage, field.TypeJSON, value)
 	}
+	if value, ok := pu.mutation.Labels(); ok {
+		_spec.SetField(policies.FieldLabels, field.TypeJSON, value)
+	}
+	if pu.mutation.LabelsCleared() {
+		_spec.ClearField(policies.FieldLabels, field.TypeJSON)
+	}
 	if value, ok := pu.mutation.Trigger(); ok {
 		_spec.SetField(policies.FieldTrigger, field.TypeJSON, value)
 	}
@@ -287,6 +313,26 @@ func (puo *PoliciesUpdateOne) SetNillableImage(s *schema.Image) *PoliciesUpdateO
 	if s != nil {
 		puo.SetImage(*s)
 	}
+	return puo
+}
+
+// SetLabels sets the "labels" field.
+func (puo *PoliciesUpdateOne) SetLabels(sl schema.PolicyLabels) *PoliciesUpdateOne {
+	puo.mutation.SetLabels(sl)
+	return puo
+}
+
+// SetNillableLabels sets the "labels" field if the given value is not nil.
+func (puo *PoliciesUpdateOne) SetNillableLabels(sl *schema.PolicyLabels) *PoliciesUpdateOne {
+	if sl != nil {
+		puo.SetLabels(*sl)
+	}
+	return puo
+}
+
+// ClearLabels clears the value of the "labels" field.
+func (puo *PoliciesUpdateOne) ClearLabels() *PoliciesUpdateOne {
+	puo.mutation.ClearLabels()
 	return puo
 }
 
@@ -447,6 +493,12 @@ func (puo *PoliciesUpdateOne) sqlSave(ctx context.Context) (_node *Policies, err
 	}
 	if value, ok := puo.mutation.Image(); ok {
 		_spec.SetField(policies.FieldImage, field.TypeJSON, value)
+	}
+	if value, ok := puo.mutation.Labels(); ok {
+		_spec.SetField(policies.FieldLabels, field.TypeJSON, value)
+	}
+	if puo.mutation.LabelsCleared() {
+		_spec.ClearField(policies.FieldLabels, field.TypeJSON)
 	}
 	if value, ok := puo.mutation.Trigger(); ok {
 		_spec.SetField(policies.FieldTrigger, field.TypeJSON, value)

--- a/ent/schema/policies.go
+++ b/ent/schema/policies.go
@@ -12,6 +12,11 @@ type Policies struct {
 	ent.Schema
 }
 
+type PolicyLabel struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 type Image struct {
 	Registry string   `json:"registry"`
 	Name     string   `json:"name"`
@@ -37,6 +42,9 @@ func (Policies) Fields() []ent.Field {
 			Comment("Policy name."),
 		field.JSON("image", Image{}).
 			Comment("Stores image details like registry, tags."),
+		field.JSON("labels", PolicyLabels{}).
+			Optional().
+			Comment("Policies labels key:value"),
 		// Todo: Trigger is optional
 		field.JSON("trigger", map[string]interface{}{}).
 			Optional().

--- a/internal/restapi/v1/policies/delete.go
+++ b/internal/restapi/v1/policies/delete.go
@@ -36,11 +36,15 @@ func DeletePolicy(client *ent.Client) func(ctx context.Context, req DeletePolicy
 		// Check if the policy exists
 		exists, err := tx.Policies.Query().Where(policies.ID(req.ID)).Exist(ctx)
 		if err != nil {
-			tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				fmt.Printf("rollback failed: %v\n", rollbackErr)
+			}
 			return status.Wrap(fmt.Errorf("failed to query policy: %v", err), status.Internal)
 		}
 		if !exists {
-			tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				fmt.Printf("rollback failed: %v\n", rollbackErr)
+			}
 			return status.Wrap(errors.New("policy not found"), status.NotFound)
 		}
 
@@ -49,7 +53,9 @@ func DeletePolicy(client *ent.Client) func(ctx context.Context, req DeletePolicy
 			Where(policylabels.PolicyID(req.ID)).
 			Exec(ctx)
 		if err != nil {
-			tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				fmt.Printf("rollback failed: %v\n", rollbackErr)
+			}
 			return status.Wrap(fmt.Errorf("failed to delete policy labels: %v", err), status.Internal)
 		}
 

--- a/internal/restapi/v1/policies/delete.go
+++ b/internal/restapi/v1/policies/delete.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/shinobistack/gokakashi/ent"
+	"github.com/shinobistack/gokakashi/ent/policies"
+	"github.com/shinobistack/gokakashi/ent/policylabels"
 	"github.com/swaggest/usecase/status"
 )
 
@@ -25,21 +27,45 @@ func DeletePolicy(client *ent.Client) func(ctx context.Context, req DeletePolicy
 			return status.Wrap(errors.New("invalid UUID: cannot be nil"), status.InvalidArgument)
 		}
 
-		// Check if the policy exists
-		_, err := client.Policies.Get(ctx, req.ID)
+		// Start a transaction
+		tx, err := client.Tx(ctx)
 		if err != nil {
-			if ent.IsNotFound(err) {
-				return status.Wrap(errors.New("policy not found"), status.NotFound)
-			}
-			return status.Wrap(fmt.Errorf("unexpected error: %v", err), status.Internal)
+			return status.Wrap(fmt.Errorf("failed to start transaction: %v", err), status.Internal)
+		}
+
+		// Check if the policy exists
+		exists, err := tx.Policies.Query().Where(policies.ID(req.ID)).Exist(ctx)
+		if err != nil {
+			tx.Rollback()
+			return status.Wrap(fmt.Errorf("failed to query policy: %v", err), status.Internal)
+		}
+		if !exists {
+			tx.Rollback()
+			return status.Wrap(errors.New("policy not found"), status.NotFound)
+		}
+
+		// Delete associated labels
+		_, err = tx.PolicyLabels.Delete().
+			Where(policylabels.PolicyID(req.ID)).
+			Exec(ctx)
+		if err != nil {
+			tx.Rollback()
+			return status.Wrap(fmt.Errorf("failed to delete policy labels: %v", err), status.Internal)
 		}
 
 		// Delete the policy
-		err = client.Policies.DeleteOneID(req.ID).Exec(ctx)
+		err = tx.Policies.DeleteOneID(req.ID).Exec(ctx)
 		if err != nil {
+			tx.Rollback()
 			return status.Wrap(fmt.Errorf("failed to delete policy: %v", err), status.Internal)
 		}
 
+		// Commit the transaction
+		if err := tx.Commit(); err != nil {
+			return status.Wrap(fmt.Errorf("failed to commit transaction: %v", err), status.Internal)
+		}
+
+		// Build the response
 		res.ID = req.ID
 		res.Status = "deleted"
 		return nil

--- a/internal/restapi/v1/policies/delete.go
+++ b/internal/restapi/v1/policies/delete.go
@@ -62,7 +62,9 @@ func DeletePolicy(client *ent.Client) func(ctx context.Context, req DeletePolicy
 		// Delete the policy
 		err = tx.Policies.DeleteOneID(req.ID).Exec(ctx)
 		if err != nil {
-			tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				fmt.Printf("rollback failed: %v\n", rollbackErr)
+			}
 			return status.Wrap(fmt.Errorf("failed to delete policy: %v", err), status.Internal)
 		}
 

--- a/internal/restapi/v1/policies/get.go
+++ b/internal/restapi/v1/policies/get.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/shinobistack/gokakashi/ent"
+	"github.com/shinobistack/gokakashi/ent/policies"
 	"github.com/shinobistack/gokakashi/ent/schema"
 	"github.com/swaggest/usecase/status"
 )
@@ -19,6 +20,7 @@ type GetPolicyResponse struct {
 	ID      uuid.UUID              `json:"id"`
 	Name    string                 `json:"name"`
 	Image   schema.Image           `json:"image"`
+	Labels  []schema.PolicyLabel   `json:"labels"`
 	Trigger map[string]interface{} `json:"trigger,omitempty"`
 	Check   *schema.Check          `json:"check,omitempty"`
 }
@@ -31,8 +33,10 @@ type ListPoliciesResponse struct {
 
 func ListPolicies(client *ent.Client) func(ctx context.Context, req ListPoliciesRequest, res *[]GetPolicyResponse) error {
 	return func(ctx context.Context, req ListPoliciesRequest, res *[]GetPolicyResponse) error {
-		// Query all policies
-		policies, err := client.Policies.Query().All(ctx)
+		// Query all policies with their labels
+		policies, err := client.Policies.Query().
+			WithPolicyLabels().
+			All(ctx)
 		if err != nil {
 			return status.Wrap(errors.New("failed to fetch policies"), status.Internal)
 		}
@@ -40,10 +44,16 @@ func ListPolicies(client *ent.Client) func(ctx context.Context, req ListPolicies
 		// Build the response
 		*res = make([]GetPolicyResponse, len(policies))
 		for i, policy := range policies {
+			labels := make([]schema.PolicyLabel, len(policy.Edges.PolicyLabels))
+			for j, label := range policy.Edges.PolicyLabels {
+				labels[j] = schema.PolicyLabel{Key: label.Key, Value: label.Value}
+			}
+
 			(*res)[i] = GetPolicyResponse{
 				ID:      policy.ID,
 				Name:    policy.Name,
 				Image:   policy.Image,
+				Labels:  labels,
 				Trigger: policy.Trigger,
 				Check:   convertToPointer(policy.Check),
 			}
@@ -59,19 +69,29 @@ func GetPolicy(client *ent.Client) func(ctx context.Context, req GetPolicyReques
 			return status.Wrap(errors.New("invalid UUID: cannot be nil"), status.InvalidArgument)
 		}
 
-		// Fetch the policy by ID
-		policy, err := client.Policies.Get(ctx, req.ID)
+		// Fetch the policy by ID with its labels
+		policy, err := client.Policies.Query().
+			Where(policies.ID(req.ID)).
+			WithPolicyLabels(). // Include related policy labels
+			Only(ctx)
 		if err != nil {
 			if ent.IsNotFound(err) {
-				return status.Wrap(errors.New("integration not found"), status.NotFound)
+				return status.Wrap(errors.New("policy not found"), status.NotFound)
 			}
 			return status.Wrap(fmt.Errorf("unexpected error: %v", err), status.Internal)
+		}
+
+		// Map the labels
+		labels := make([]schema.PolicyLabel, len(policy.Edges.PolicyLabels))
+		for i, label := range policy.Edges.PolicyLabels {
+			labels[i] = schema.PolicyLabel{Key: label.Key, Value: label.Value}
 		}
 
 		// Build the response
 		res.ID = policy.ID
 		res.Name = policy.Name
 		res.Image = policy.Image
+		res.Labels = labels
 		res.Trigger = policy.Trigger
 		res.Check = convertToPointer(policy.Check)
 

--- a/internal/restapi/v1/policies/post.go
+++ b/internal/restapi/v1/policies/post.go
@@ -74,7 +74,9 @@ func CreatePolicy(client *ent.Client) func(ctx context.Context, req CreatePolicy
 			SetNillableCheck(req.Check).
 			Save(ctx)
 		if err != nil {
-			tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				fmt.Printf("rollback failed: %v\n", rollbackErr)
+			}
 			return status.Wrap(err, status.Internal)
 		}
 

--- a/internal/restapi/v1/policies/post.go
+++ b/internal/restapi/v1/policies/post.go
@@ -91,7 +91,9 @@ func CreatePolicy(client *ent.Client) func(ctx context.Context, req CreatePolicy
 			}
 
 			if _, err := tx.PolicyLabels.CreateBulk(bulk...).Save(ctx); err != nil {
-				tx.Rollback()
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					fmt.Printf("rollback failed: %v\n", rollbackErr)
+				}
 				return status.Wrap(err, status.Internal)
 			}
 		}

--- a/internal/restapi/v1/policies/post.go
+++ b/internal/restapi/v1/policies/post.go
@@ -14,8 +14,9 @@ import (
 )
 
 type CreatePolicyRequest struct {
-	Name  string       `json:"name"`
-	Image schema.Image `json:"image"`
+	Name   string               `json:"name"`
+	Image  schema.Image         `json:"image"`
+	Labels []schema.PolicyLabel `json:"labels"`
 	// Todo: Implement the logic of Type:cron etc
 	Trigger map[string]interface{} `json:"trigger"`
 	Check   *schema.Check          `json:"check"`
@@ -28,7 +29,6 @@ type CreatePolicyResponse struct {
 
 func CreatePolicy(client *ent.Client) func(ctx context.Context, req CreatePolicyRequest, res *CreatePolicyResponse) error {
 	return func(ctx context.Context, req CreatePolicyRequest, res *CreatePolicyResponse) error {
-		// Todo: Name validation
 		// Validate image fields
 		if req.Image.Registry == "" || req.Image.Name == "" || len(req.Image.Tags) == 0 {
 			return status.Wrap(errors.New("invalid image: missing required fields"), status.InvalidArgument)
@@ -61,15 +61,41 @@ func CreatePolicy(client *ent.Client) func(ctx context.Context, req CreatePolicy
 			return status.Wrap(errors.New("invalid check: missing required fields"), status.InvalidArgument)
 		}
 
-		// Save policy to database
-		policy, err := client.Policies.Create().
+		tx, err := client.Tx(ctx)
+		if err != nil {
+			return status.Wrap(err, status.Internal)
+		}
+
+		// Save the policy
+		policy, err := tx.Policies.Create().
 			SetName(req.Name).
 			SetImage(req.Image).
 			SetTrigger(req.Trigger).
 			SetNillableCheck(req.Check).
 			Save(ctx)
 		if err != nil {
-			return status.Wrap(fmt.Errorf("failed to create policy: %v", err), status.Internal)
+			tx.Rollback()
+			return status.Wrap(err, status.Internal)
+		}
+
+		// Save policy labels
+		if len(req.Labels) > 0 {
+			bulk := make([]*ent.PolicyLabelsCreate, len(req.Labels))
+			for i, label := range req.Labels {
+				bulk[i] = tx.PolicyLabels.Create().
+					SetPolicyID(policy.ID).
+					SetKey(label.Key).
+					SetValue(label.Value)
+			}
+
+			if _, err := tx.PolicyLabels.CreateBulk(bulk...).Save(ctx); err != nil {
+				tx.Rollback()
+				return status.Wrap(err, status.Internal)
+			}
+		}
+
+		if err := tx.Commit(); err != nil {
+			return status.Wrap(err, status.Internal)
 		}
 
 		res.ID = policy.ID

--- a/internal/restapi/v1/policylabels/delete.go
+++ b/internal/restapi/v1/policylabels/delete.go
@@ -1,0 +1,68 @@
+package policylabels
+
+import (
+	"context"
+	"errors"
+	"github.com/google/uuid"
+	"github.com/shinobistack/gokakashi/ent"
+	"github.com/shinobistack/gokakashi/ent/policylabels"
+	"github.com/swaggest/usecase/status"
+)
+
+type DeletePolicyLabelRequest struct {
+	PolicyID uuid.UUID `path:"policy_id"`
+	Key      string    `path:"key"`
+	Value    string    `query:"value"`
+}
+
+type DeletePolicyLabelResponse struct {
+	Status string `json:"status"`
+}
+
+func DeletePolicyLabel(client *ent.Client) func(ctx context.Context, req DeletePolicyLabelRequest, res *DeletePolicyLabelResponse) error {
+	return func(ctx context.Context, req DeletePolicyLabelRequest, res *DeletePolicyLabelResponse) error {
+		// Validate inputs
+		if req.PolicyID == uuid.Nil {
+			return status.Wrap(errors.New("invalid Policy ID: cannot be nil"), status.InvalidArgument)
+		}
+		if req.Key == "" {
+			return status.Wrap(errors.New("invalid Key: cannot be empty"), status.InvalidArgument)
+		}
+		if req.Value == "" {
+			return status.Wrap(errors.New("invalid Value: cannot be empty"), status.InvalidArgument)
+		}
+
+		// Check if the label exists
+		exists, err := client.PolicyLabels.Query().
+			Where(
+				policylabels.PolicyID(req.PolicyID),
+				policylabels.Key(req.Key),
+				policylabels.Value(req.Value),
+			).
+			Exist(ctx)
+
+		if err != nil {
+			return status.Wrap(err, status.Internal)
+		}
+
+		if !exists {
+			return status.Wrap(errors.New("label not found"), status.NotFound)
+		}
+
+		// Delete the label
+		_, err = client.PolicyLabels.Delete().
+			Where(
+				policylabels.PolicyID(req.PolicyID),
+				policylabels.Key(req.Key),
+				policylabels.Value(req.Value),
+			).
+			Exec(ctx)
+
+		if err != nil {
+			return status.Wrap(err, status.Internal)
+		}
+
+		res.Status = "deleted"
+		return nil
+	}
+}

--- a/internal/restapi/v1/policylabels/delete_test.go
+++ b/internal/restapi/v1/policylabels/delete_test.go
@@ -1,0 +1,65 @@
+package policylabels_test
+
+import (
+	"context"
+	"github.com/shinobistack/gokakashi/ent/enttest"
+	"github.com/shinobistack/gokakashi/ent/schema"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/policylabels"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDeletePolicyLabel_Valid(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("team").
+		SetValue("gokakashi").
+		SaveX(context.Background())
+
+	req := policylabels.DeletePolicyLabelRequest{
+		PolicyID: policy.ID,
+		Key:      "team",
+		Value:    "gokakashi",
+	}
+	res := &policylabels.DeletePolicyLabelResponse{}
+
+	err := policylabels.DeletePolicyLabel(client)(context.Background(), req, res)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "deleted", res.Status)
+}
+
+func TestDeletePolicyLabel_NonExistentLabel(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("team").
+		SetValue("gokakashi").
+		SaveX(context.Background())
+
+	req := policylabels.DeletePolicyLabelRequest{
+		PolicyID: policy.ID,
+		Key:      "dev",
+		Value:    "role",
+	}
+	res := &policylabels.DeletePolicyLabelResponse{}
+
+	err := policylabels.DeletePolicyLabel(client)(context.Background(), req, res)
+
+	assert.Error(t, err)
+}

--- a/internal/restapi/v1/policylabels/get.go
+++ b/internal/restapi/v1/policylabels/get.go
@@ -1,0 +1,86 @@
+package policylabels
+
+import (
+	"context"
+	"errors"
+	"github.com/google/uuid"
+	"github.com/shinobistack/gokakashi/ent"
+	"github.com/shinobistack/gokakashi/ent/policylabels"
+	"github.com/swaggest/usecase/status"
+)
+
+type ListPolicyLabelsRequest struct {
+	PolicyID uuid.UUID `path:"policy_id"`
+	Keys     []string  `query:"key"`
+}
+
+type PolicyLabel struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type ListPolicyLabelsResponse struct {
+	Labels []PolicyLabel `json:"labels"`
+}
+
+type GetPolicyLabelRequest struct {
+	PolicyID uuid.UUID `path:"policy_id"`
+	Key      string    `path:"key"`
+}
+
+type GetPolicyLabelResponse struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func ListPolicyLabels(client *ent.Client) func(ctx context.Context, req ListPolicyLabelsRequest, res *ListPolicyLabelsResponse) error {
+	return func(ctx context.Context, req ListPolicyLabelsRequest, res *ListPolicyLabelsResponse) error {
+		// Validate inputs
+		if req.PolicyID == uuid.Nil {
+			return status.Wrap(errors.New("invalid Policy ID"), status.InvalidArgument)
+		}
+
+		query := client.PolicyLabels.Query().Where(policylabels.PolicyID(req.PolicyID))
+
+		// Filter by keys if provided
+		if len(req.Keys) > 0 {
+			query = query.Where(policylabels.KeyIn(req.Keys...))
+		}
+
+		labels, err := query.All(ctx)
+		if err != nil {
+			return status.Wrap(err, status.Internal)
+		}
+
+		// Build the response
+		res.Labels = make([]PolicyLabel, len(labels))
+		for i, label := range labels {
+			res.Labels[i] = PolicyLabel{Key: label.Key, Value: label.Value}
+		}
+		return nil
+	}
+}
+
+func GetPolicyLabel(client *ent.Client) func(ctx context.Context, req GetPolicyLabelRequest, res *GetPolicyLabelResponse) error {
+	return func(ctx context.Context, req GetPolicyLabelRequest, res *GetPolicyLabelResponse) error {
+		// Validate inputs
+		if req.PolicyID == uuid.Nil || req.Key == "" {
+			return status.Wrap(errors.New("invalid Policy ID or Key"), status.InvalidArgument)
+		}
+
+		// Query the label
+		label, err := client.PolicyLabels.Query().
+			Where(policylabels.PolicyID(req.PolicyID), policylabels.Key(req.Key)).
+			Only(ctx)
+		if err != nil {
+			if ent.IsNotFound(err) {
+				return status.Wrap(errors.New("label not found"), status.NotFound)
+			}
+			return status.Wrap(err, status.Internal)
+		}
+
+		res.Key = label.Key
+		res.Value = label.Value
+		return nil
+	}
+}

--- a/internal/restapi/v1/policylabels/get_test.go
+++ b/internal/restapi/v1/policylabels/get_test.go
@@ -1,0 +1,106 @@
+package policylabels_test
+
+import (
+	"context"
+	"github.com/shinobistack/gokakashi/ent/enttest"
+	"github.com/shinobistack/gokakashi/ent/schema"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/policylabels"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestListPolicyLabels_Valid(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("env").
+		SetValue("prod").
+		SaveX(context.Background())
+
+	req := policylabels.ListPolicyLabelsRequest{PolicyID: policy.ID}
+	res := &policylabels.ListPolicyLabelsResponse{}
+
+	err := policylabels.ListPolicyLabels(client)(context.Background(), req, res)
+
+	assert.NoError(t, err)
+	assert.Len(t, res.Labels, 1)
+	assert.Equal(t, "env", res.Labels[0].Key)
+	assert.Equal(t, "prod", res.Labels[0].Value)
+}
+
+func TestListPolicyLabels_NoLabels(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+	req := policylabels.ListPolicyLabelsRequest{PolicyID: policy.ID}
+	res := &policylabels.ListPolicyLabelsResponse{}
+
+	err := policylabels.ListPolicyLabels(client)(context.Background(), req, res)
+
+	assert.NoError(t, err)
+	assert.Empty(t, res.Labels)
+}
+
+func TestGetPolicyLabel_SpecificLabel(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("env").
+		SetValue("prod").
+		SaveX(context.Background())
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("team").
+		SetValue("gokakashi").
+		SaveX(context.Background())
+
+	req := policylabels.GetPolicyLabelRequest{PolicyID: policy.ID, Key: "team"}
+	res := &policylabels.GetPolicyLabelResponse{}
+
+	err := policylabels.GetPolicyLabel(client)(context.Background(), req, res)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "team", res.Key)
+	assert.Equal(t, "gokakashi", res.Value)
+
+}
+
+func TestGetPolicyLabel_NonExistentLabel(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("team").
+		SetValue("gokakashi").
+		SaveX(context.Background())
+
+	req := policylabels.GetPolicyLabelRequest{PolicyID: policy.ID, Key: "env"}
+	res := &policylabels.GetPolicyLabelResponse{}
+
+	err := policylabels.GetPolicyLabel(client)(context.Background(), req, res)
+
+	assert.Error(t, err)
+}

--- a/internal/restapi/v1/policylabels/post.go
+++ b/internal/restapi/v1/policylabels/post.go
@@ -1,0 +1,57 @@
+package policylabels
+
+import (
+	"context"
+	"errors"
+	"github.com/google/uuid"
+	"github.com/shinobistack/gokakashi/ent"
+	"github.com/swaggest/usecase/status"
+)
+
+type CreatePolicyLabelRequest struct {
+	PolicyID uuid.UUID `path:"policy_id"`
+	Key      string    `json:"key"`
+	Value    string    `json:"value"`
+}
+
+type CreatePolicyLabelResponse struct {
+	ID     uuid.UUID `json:"id"`
+	Status string    `json:"status"`
+}
+
+// ToDO: When extra fields are passed?
+func CreatePolicyLabel(client *ent.Client) func(ctx context.Context, req CreatePolicyLabelRequest, res *CreatePolicyLabelResponse) error {
+	return func(ctx context.Context, req CreatePolicyLabelRequest, res *CreatePolicyLabelResponse) error {
+		// Validate inputs
+		if req.PolicyID == uuid.Nil {
+			return status.Wrap(errors.New("invalid Policy ID"), status.InvalidArgument)
+		}
+		if req.Key == "" || req.Value == "" {
+			return status.Wrap(errors.New("key and value must not be empty"), status.InvalidArgument)
+		}
+
+		// Ensure the policy exists
+		_, err := client.Policies.Get(ctx, req.PolicyID)
+		if err != nil {
+			if ent.IsNotFound(err) {
+				return status.Wrap(errors.New("policy not found"), status.NotFound)
+			}
+			return status.Wrap(err, status.Internal)
+		}
+
+		// Create the policy label
+		// ToDo: append the key
+		label, err := client.PolicyLabels.Create().
+			SetPolicyID(req.PolicyID).
+			SetKey(req.Key).
+			SetValue(req.Value).
+			Save(ctx)
+		if err != nil {
+			return status.Wrap(err, status.Internal)
+		}
+
+		res.ID = label.PolicyID
+		res.Status = "created"
+		return nil
+	}
+}

--- a/internal/restapi/v1/policylabels/post_test.go
+++ b/internal/restapi/v1/policylabels/post_test.go
@@ -1,0 +1,76 @@
+package policylabels_test
+
+import (
+	"context"
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/shinobistack/gokakashi/ent/enttest"
+	"github.com/shinobistack/gokakashi/ent/schema"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/policylabels"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCreatePolicyLabel_Valid(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	req := policylabels.CreatePolicyLabelRequest{
+		PolicyID: policy.ID,
+		Key:      "env",
+		Value:    "prod",
+	}
+	res := &policylabels.CreatePolicyLabelResponse{}
+
+	err := policylabels.CreatePolicyLabel(client)(context.Background(), req, res)
+
+	assert.NoError(t, err)
+	assert.Equal(t, req.PolicyID, res.ID)
+	assert.Len(t, res.Labels, 1)
+	assert.Equal(t, req.Key, res.Labels[0].Key)
+	assert.Equal(t, req.Value, res.Labels[0].Value)
+
+}
+
+func TestCreatePolicyLabel_Invalid(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	req := policylabels.CreatePolicyLabelRequest{PolicyID: uuid.Nil, Key: "", Value: ""}
+	res := &policylabels.CreatePolicyLabelResponse{}
+
+	err := policylabels.CreatePolicyLabel(client)(context.Background(), req, res)
+
+	assert.Error(t, err)
+}
+
+func TestCreatePolicyLabel_Duplicate(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("env").
+		SetValue("prod").
+		SaveX(context.Background())
+
+	req := policylabels.CreatePolicyLabelRequest{
+		PolicyID: policy.ID,
+		Key:      "env",
+		Value:    "prod",
+	}
+	res := &policylabels.CreatePolicyLabelResponse{}
+
+	err := policylabels.CreatePolicyLabel(client)(context.Background(), req, res)
+
+	assert.Error(t, err)
+}

--- a/internal/restapi/v1/policylabels/put.go
+++ b/internal/restapi/v1/policylabels/put.go
@@ -1,0 +1,112 @@
+package policylabels
+
+import (
+	"context"
+	"errors"
+	"github.com/google/uuid"
+	"github.com/shinobistack/gokakashi/ent"
+	"github.com/shinobistack/gokakashi/ent/policylabels"
+	"github.com/swaggest/usecase/status"
+)
+
+type UpdatePolicyLabelsRequest struct {
+	PolicyID uuid.UUID     `path:"policy_id"`
+	Labels   []PolicyLabel `json:"labels"`
+	Key      *string       `json:"key"`
+	Value    *string       `json:"value"`
+}
+
+type UpdatePolicyLabelsResponse struct {
+	Labels []PolicyLabel `json:"labels"`
+}
+
+func UpdatePolicyLabels(client *ent.Client) func(ctx context.Context, req UpdatePolicyLabelsRequest, res *UpdatePolicyLabelsResponse) error {
+	return func(ctx context.Context, req UpdatePolicyLabelsRequest, res *UpdatePolicyLabelsResponse) error {
+		// Validate PolicyID
+		if req.PolicyID == uuid.Nil {
+			return status.Wrap(errors.New("invalid Policy ID"), status.InvalidArgument)
+		}
+
+		if req.Key != nil && req.Value != nil {
+			// Update a specific label
+			_, err := client.PolicyLabels.Update().
+				Where(policylabels.PolicyID(req.PolicyID), policylabels.Key(*req.Key)).
+				SetValue(*req.Value).
+				Save(ctx)
+			if err != nil {
+				if ent.IsNotFound(err) {
+					return status.Wrap(errors.New("label not found"), status.NotFound)
+				}
+				return status.Wrap(err, status.Internal)
+			}
+
+			updatedLabel, err := client.PolicyLabels.Query().
+				Where(policylabels.PolicyID(req.PolicyID), policylabels.Key(*req.Key)).
+				Only(ctx)
+			if err != nil {
+				if ent.IsNotFound(err) {
+					return status.Wrap(errors.New("label not found after update"), status.NotFound)
+				}
+				return status.Wrap(err, status.Internal)
+			}
+
+			// Return the updated label
+			res.Labels = []PolicyLabel{
+				{
+					Key:   updatedLabel.Key,
+					Value: updatedLabel.Value,
+				},
+			}
+			return nil
+		}
+
+		if req.Labels != nil {
+			// Replace all labels
+			tx, err := client.Tx(ctx)
+			if err != nil {
+				return status.Wrap(err, status.Internal)
+			}
+
+			// Delete existing labels
+			_, err = tx.PolicyLabels.Delete().
+				Where(policylabels.PolicyID(req.PolicyID)).
+				Exec(ctx)
+			if err != nil {
+				tx.Rollback()
+				return status.Wrap(err, status.Internal)
+			}
+
+			// Add new labels
+			bulk := make([]*ent.PolicyLabelsCreate, len(req.Labels))
+			for i, label := range req.Labels {
+				bulk[i] = tx.PolicyLabels.Create().
+					SetPolicyID(req.PolicyID).
+					SetKey(label.Key).
+					SetValue(label.Value)
+			}
+
+			createdLabels, err := tx.PolicyLabels.CreateBulk(bulk...).Save(ctx)
+			if err != nil {
+				tx.Rollback()
+				return status.Wrap(err, status.Internal)
+			}
+
+			err = tx.Commit()
+			if err != nil {
+				return status.Wrap(err, status.Internal)
+			}
+
+			// Build the response
+			res.Labels = make([]PolicyLabel, len(createdLabels))
+			for i, label := range createdLabels {
+				res.Labels[i] = PolicyLabel{
+					Key:   label.Key,
+					Value: label.Value,
+				}
+			}
+			return nil
+		}
+
+		return status.Wrap(errors.New("invalid request: either key-value or labels must be provided"), status.InvalidArgument)
+	}
+}

--- a/internal/restapi/v1/policylabels/put.go
+++ b/internal/restapi/v1/policylabels/put.go
@@ -90,7 +90,9 @@ func UpdatePolicyLabels(client *ent.Client) func(ctx context.Context, req Update
 
 			createdLabels, err := tx.PolicyLabels.CreateBulk(bulk...).Save(ctx)
 			if err != nil {
-				tx.Rollback()
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					fmt.Printf("rollback failed: %v\n", rollbackErr)
+				}
 				return status.Wrap(err, status.Internal)
 			}
 

--- a/internal/restapi/v1/policylabels/put.go
+++ b/internal/restapi/v1/policylabels/put.go
@@ -3,6 +3,7 @@ package policylabels
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/google/uuid"
 	"github.com/shinobistack/gokakashi/ent"
 	"github.com/shinobistack/gokakashi/ent/policylabels"
@@ -72,7 +73,9 @@ func UpdatePolicyLabels(client *ent.Client) func(ctx context.Context, req Update
 				Where(policylabels.PolicyID(req.PolicyID)).
 				Exec(ctx)
 			if err != nil {
-				tx.Rollback()
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					fmt.Printf("rollback failed: %v\n", rollbackErr)
+				}
 				return status.Wrap(err, status.Internal)
 			}
 

--- a/internal/restapi/v1/policylabels/put_test.go
+++ b/internal/restapi/v1/policylabels/put_test.go
@@ -1,0 +1,82 @@
+package policylabels_test
+
+import (
+	"context"
+	"github.com/shinobistack/gokakashi/ent/enttest"
+	"github.com/shinobistack/gokakashi/ent/schema"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/policylabels"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Todo: Certainly can better this logic to check for single label update
+func TestUpdatePolicyLabel_SingleLabel(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("team").
+		SetValue("gokakashi").
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("env").
+		SetValue("prod").
+		SaveX(context.Background())
+
+	req := policylabels.UpdatePolicyLabelsRequest{
+		PolicyID: policy.ID,
+		Key:      StringPointer("env"),
+		Value:    StringPointer("dev"),
+	}
+	res := &policylabels.UpdatePolicyLabelsResponse{}
+
+	err := policylabels.UpdatePolicyLabels(client)(context.Background(), req, res)
+	assert.NoError(t, err)
+	assert.Equal(t, "dev", res.Labels[0].Value)
+}
+
+func TestUpdatePolicyLabel_AllLabels(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	policy := client.Policies.Create().
+		SetName("to-be-deleted-test-policy").
+		SetImage(schema.Image{Registry: "example-registry", Name: "example-name", Tags: []string{"v1.0"}}).
+		SaveX(context.Background())
+
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("env").
+		SetValue("prod").
+		SaveX(context.Background())
+	client.PolicyLabels.Create().
+		SetPolicyID(policy.ID).
+		SetKey("team").
+		SetValue("gokakashi").
+		SaveX(context.Background())
+
+	req := policylabels.UpdatePolicyLabelsRequest{
+		PolicyID: policy.ID,
+		Labels: []policylabels.PolicyLabel{
+			{Key: "updated", Value: "all"},
+		},
+	}
+	res := &policylabels.UpdatePolicyLabelsResponse{}
+
+	err := policylabels.UpdatePolicyLabels(client)(context.Background(), req, res)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "all", res.Labels[0].Value)
+}
+
+func StringPointer(s string) *string {
+	return &s
+}

--- a/internal/restapi/v1/server.go
+++ b/internal/restapi/v1/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shinobistack/gokakashi/internal/restapi/server/middleware"
 	integrations1 "github.com/shinobistack/gokakashi/internal/restapi/v1/integrations"
 	policies1 "github.com/shinobistack/gokakashi/internal/restapi/v1/policies"
+	policylabels1 "github.com/shinobistack/gokakashi/internal/restapi/v1/policylabels"
 	"github.com/swaggest/openapi-go/openapi31"
 	"github.com/swaggest/rest/web"
 	swg "github.com/swaggest/swgui"
@@ -55,6 +56,12 @@ func (srv *Server) Service() *web.Service {
 	apiV1.Get("/policies/{id}", usecase.NewInteractor(policies1.GetPolicy(srv.DB)))
 	apiV1.Put("/policies/{id}", usecase.NewInteractor(policies1.UpdatePolicy(srv.DB)))
 	apiV1.Delete("/policies/{id}", usecase.NewInteractor(policies1.DeletePolicy(srv.DB)))
+
+	apiV1.Post("/policies/{policy_id}/labels", usecase.NewInteractor(policylabels1.CreatePolicyLabel(srv.DB)))
+	apiV1.Get("/policies/{policy_id}/labels", usecase.NewInteractor(policylabels1.ListPolicyLabels(srv.DB)))
+	apiV1.Get("/policies/{policy_id}/labels/{key}", usecase.NewInteractor(policylabels1.GetPolicyLabel(srv.DB)))
+	apiV1.Put("/policies/{policy_id}/labels", usecase.NewInteractor(policylabels1.UpdatePolicyLabels(srv.DB)))
+	apiV1.Delete("/policies/{policy_id}/labels/{key}", usecase.NewInteractor(policylabels1.DeletePolicyLabel(srv.DB)))
 
 	s.Mount("/api/v1/openapi.json", specHandler(apiV1.OpenAPICollector.SpecSchema().(*openapi31.Spec)))
 	s.Mount("/api/v1", apiV1)


### PR DESCRIPTION
closes #52 

### Introduces 
- CRUD operations
- OpenAPI spec
- logic dependent on policies + policylabels
- adds test cases #53 

As follows



Action | Method | Endpoint | Description
-- | -- | -- | --
Create | POST | /policies/{policy_id}/labels | Add a new label to a policy.
Read (List) | GET | /policies/{policy_id}/labels | List all labels for a specific policy.
Read (Multiple keys) | GET | /policies/{policy_id}/labels?key={key1}&key={key2} | Returns labels matching the provided keys for the specified policy_id
Read (Detail) | GET | /policies/{policy_id}/labels/{key} | Returns labels matching the provided single key for the specified policy_id
Update | PUT | /policies/{policy_id}/labels/{key} | Update a specific label by key.
Delete | DELETE | /policies/{policy_id}/labels/{key} | Delete a specific label by key.


<!-- notionvc: 97d4313e-da3b-47d0-8996-46b64ecb8d0e -->

cURL

```
curl -X POST \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
-d '{
  "key": "newkey",
  "value": "new_value"
}' \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels

```
```
curl -X GET \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels


curl -X GET \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels?key=env&key=lts_version

curl -X GET \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels/lts_version

```
```
curl -X PUT \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
-d '{
  "key": "newkey",
  "value": "updated_value"
}' \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels

curl -X PUT \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
-d '{
  "labels": [
    {"key": "lts_version", "value": "v1.0"},
    {"key": "team", "value": "gokakashi"}
  ]
}' \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels

```
```
curl -X DELETE \
-H "Authorization: Bearer letsdoit" \
-H "Content-Type: application/json" \
-d '{
  "value": "v1.0"
}' \
http://localhost:8000/api/v1/policies/2fe7c0e8-e042-4e35-bb7f-1b0c20f40d59/labels/lts_version

```



<p>POST <code>/policies/{policy_id}/labels</code></p>

Test Case | Description | Error Handling
-- | -- | --
Valid Input | Ensure a new label is created successfully for a policy. ✅ | Response contains key and value of the created label. ✅
Missing Required Fields | Verify error when policy_id, key, or value is not provided. ✅ | Returns 400 Bad Request. ✅
Duplicate Key for Same Policy ID | Verify error when the same key already exists for the policy ID. ✅ | Returns 409 Conflict. ✅


<!-- notionvc: da76549d-96fa-4e6e-a1de-631d732b028f -->

<p>GET</p>

Test Case | Description | Error Handling
-- | -- | --
List Valid Policy Labels | Retrieve all labels for a policy ID. ✅ | Returns a list of all labels with key and value. ✅
No Labels Found | Verify behavior when no labels are associated with the policy ID. ✅ | Returns an empty list. ✅
Get Specific Label | Fetch a specific label by key for a policy ID. ✅ | Response contains the key and value. ✅
Non-Existent Label or Policy ID | Verify error when attempting to fetch a non-existent label or policy ID. ✅ | Returns 404 Not Found. ✅


<!-- notionvc: bb48e5ed-aa3c-4162-a611-1146fe533331 -->

<p>PUT</p>

Test Case | Description | Error Handling
-- | -- | --
Update a Single Label | Update a specific label's value for a given policy ID. ✅ | Response contains the updated key and value. ✅
Replace All Labels | Replace all labels for a policy ID with a new set of labels. ✅ | Deletes existing labels, inserts new ones, and ensures success response. ✅
Invalid Input for Update | Verify error when invalid policy ID, key, or value is provided. | Returns 400 Bad Request. ✅


<!-- notionvc: a0f8a967-42b4-4f5a-a51c-248a025d7334 -->

<p>DELETE</p>

Test Case | Description | Error Handling
-- | -- | --
Delete Existing Label | Delete an existing label by key and value. ✅ | Response indicates successful deletion. ✅
Delete Non-Existent Label | Verify error when attempting to delete a non-existent label or policy ID. ✅ | Returns 404 Not Found. ✅
Invalid Input for Delete | Verify error when policy ID, key, or value is invalid or empty. 🔺 To be done later | Returns 400 Bad Request. ✅


<!-- notionvc: 16e1b3b2-0351-4945-bbc2-5c10de1172b6 -->

