### PR TITLE
populate CF Access headers if env is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod tidy
+RUN go mod download
 
 # Copy the source code
 COPY . .

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var httpClientKey struct{}
+type httpClientKey struct{}
 
 var agentCmd = &cobra.Command{
 	Use:   "agent",
@@ -56,7 +56,7 @@ var agentStartCmd = &cobra.Command{
 			client.WithHeaders(headers),
 		)
 
-		ctx := context.WithValue(context.Background(), httpClientKey, httpClient)
+		ctx := context.WithValue(context.Background(), httpClientKey{}, httpClient)
 		cmd.SetContext(ctx)
 	},
 	Run: agentRegister,
@@ -106,7 +106,7 @@ func registerAgent(ctx context.Context, server, token, workspace, name string) (
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to send registration request: %w", err)
 	}
@@ -161,7 +161,7 @@ func fetchTasks(ctx context.Context, server, token string, agentID int, status s
 		return nil, fmt.Errorf("failed to create task polling request: %w", err)
 	}
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send task polling request: %w", err)
 	}
@@ -194,7 +194,7 @@ func updateAgentTaskStatus(ctx context.Context, server, token string, taskID uui
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to update task status: %w", err)
 	}
@@ -286,7 +286,7 @@ func updateScanStatus(ctx context.Context, server, token string, scanID uuid.UUI
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to update scan status: %w", err)
 	}
@@ -305,7 +305,7 @@ func fetchScan(ctx context.Context, server, token string, scanID uuid.UUID) (*sc
 		return nil, fmt.Errorf("failed to create scan request: %w", err)
 	}
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch scan details: %w", err)
 	}
@@ -329,7 +329,7 @@ func fetchIntegration(ctx context.Context, server, token string, integrationID u
 		return nil, fmt.Errorf("failed to create integration fetch request: %w", err)
 	}
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch integration details: %w", err)
 	}
@@ -407,7 +407,7 @@ func uploadReport(ctx context.Context, server, token string, scanID uuid.UUID, r
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := ctx.Value(httpClientKey).(*client.Client).Do(req)
+	resp, err := ctx.Value(httpClientKey{}).(*client.Client).Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to upload scan report: %w", err)
 	}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -46,9 +46,9 @@ var agentStartCmd = &cobra.Command{
 			headers["CF-Access-Client-Id"] = cfClientID
 			headers["CF-Access-Client-Secret"] = cfClientSecret
 		} else if cfClientSecret != "" {
-			fmt.Printf("Warning: ignoring CF_ACCESS_CLIENT_SECRET because CF_ACCESS_CLIENT_ID is not set")
+			fmt.Println("Warning: ignoring CF_ACCESS_CLIENT_SECRET because CF_ACCESS_CLIENT_ID is not set")
 		} else if cfClientID != "" {
-			fmt.Printf("Warning: ignoring CF_ACCESS_CLIENT_ID because CF_ACCESS_CLIENT_SECRET is not set")
+			fmt.Println("Warning: ignoring CF_ACCESS_CLIENT_ID because CF_ACCESS_CLIENT_SECRET is not set")
 		}
 
 		httpClient := client.New(

--- a/internal/http/client/client.go
+++ b/internal/http/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"net/http"
-	"os"
 )
 
 type Client struct {
@@ -31,13 +30,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 	for k, v := range c.headers {
 		req.Header.Set(k, v)
-	}
-
-	cfClientID := os.Getenv("CF_ACCESS_CLIENT_ID")
-	cfClientSecret := os.Getenv("CF_ACCESS_CLIENT_SECRET")
-	if cfClientID != "" && cfClientSecret != "" {
-		req.Header.Set("CF-Access-Client-Id", cfClientID)
-		req.Header.Set("CF-Access-Client-Secret", cfClientSecret)
 	}
 
 	return c.client.Do(req)

--- a/internal/http/client/client.go
+++ b/internal/http/client/client.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+type Client struct {
+	client  *http.Client
+	token   string
+	headers map[string]string
+}
+
+func New(opts ...Option) *Client {
+	c := &Client{
+		client: http.DefaultClient,
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	return c
+}
+
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if c.token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	}
+
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	cfClientID := os.Getenv("CF_ACCESS_CLIENT_ID")
+	cfClientSecret := os.Getenv("CF_ACCESS_CLIENT_SECRET")
+	if cfClientID != "" && cfClientSecret != "" {
+		req.Header.Set("CF-Access-Client-Id", cfClientID)
+		req.Header.Set("CF-Access-Client-Secret", cfClientSecret)
+	}
+
+	return c.client.Do(req)
+}

--- a/internal/http/client/client_opts.go
+++ b/internal/http/client/client_opts.go
@@ -1,0 +1,23 @@
+package client
+
+import "net/http"
+
+type Option func(*Client)
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.client = client
+	}
+}
+
+func WithToken(token string) Option {
+	return func(c *Client) {
+		c.token = token
+	}
+}
+
+func WithHeaders(headers map[string]string) Option {
+	return func(c *Client) {
+		c.headers = headers
+	}
+}

--- a/internal/http/client/client_opts_test.go
+++ b/internal/http/client/client_opts_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionWithToken(t *testing.T) {
+	token := "test-token"
+	c := New(WithToken(token))
+	assert.Equal(t, token, c.token)
+}
+
+func TestOptionWithHeaders(t *testing.T) {
+	headers := map[string]string{
+		"header-a": "value-a",
+		"header-b": "value-b",
+	}
+	c := New(WithHeaders(headers))
+	assert.Equal(t, headers, c.headers)
+}
+
+func TestOptionWithHTTPClient(t *testing.T) {
+	httpclient := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	c := New(WithHTTPClient(httpclient))
+	assert.Equal(t, httpclient, c.client)
+}


### PR DESCRIPTION
env -> header
`CF_ACCESS_CLIENT_ID` -> `CF-Access-Client-Id`
`CF_ACCESS_CLIENT_SECRET` -> `CF-Access-Client-Secret`

i'm a little on the fence about how i've used context. Ideally, i would want an `Agent` struct so that the http client can be an internal state for that `Agent`.(future refactor plans :D)