### PR TITLE
cmd(server): boot up without the need for a config file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ out/
 hashes.json
 config/*.json
 scan_policy_curl.sh
-*.yaml
 
 # TODO: figure out what this is and get rid of it
 listdirectory.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,26 @@
 FROM node:22-alpine3.20 AS frontend
-
-# Set the working directory
 WORKDIR /webapp
-
 COPY webapp/package.json webapp/package-lock.json ./
-
 RUN npm install
-
 COPY webapp/ /webapp/
-
 RUN npm run build
 
-# Stage 1: Build the Go binary using Alpine
 FROM golang:1.23-alpine AS builder
-
-# Ensure the build fails on any command failure
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-
-# Install build dependencies
 RUN apk add --no-cache git bash gcc sqlite-dev musl-dev libc-dev
-
 ENV CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
-
-# Set the working directory
 WORKDIR /app
-
-# Copy go.mod and go.sum files
 COPY go.mod go.sum ./
-
-# Download dependencies
 RUN go mod tidy
-
-# Copy the source code
 COPY . .
-
 COPY --from=frontend /webapp/dist /app/webapp/dist
-
-# Run the tests.CGO is needed for using sqlite3 in tests
+# CGO is needed for using sqlite3 in tests
 RUN CGO_ENABLED=1 go test -v ./...
-
-# Build the Go binary for amd64
 RUN CGO_ENABLED=0 GOARCH=amd64 go build -o gokakashi
 
 FROM alpine:3.20
-
-# Set working directory
 WORKDIR /app
-
-# Copy the Go binary from the builder stage
 COPY --from=builder /app/gokakashi /app/gokakashi
-
-# Make sure the binary is executable
 RUN chmod +x /app/gokakashi
-
 CMD ["/app/gokakashi"]
-
-# Set the entrypoint to the application binary
 ENTRYPOINT ["/app/gokakashi"]

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -57,7 +56,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	log.Println("==== Starting gokakashi ====")
 	go startAPIServer(cfg)
 	go startWebServer(cfg)
-	logConfig(cfg)
+	log.Println(cfg)
 
 	<-done
 	log.Println("====  Exiting gokakashi. Bye! ==== ")
@@ -78,7 +77,6 @@ func startAPIServer(cfg *configv1.Config) {
 	configDB := restapiv1.InitDB(dbConfig)
 	defer configDB.Close()
 	db.RunMigrations(configDB)
-	// Populate the database
 	db.PopulateDatabase(configDB, cfg)
 
 	// ToDo: To be go routine who independently and routinely checks and assigns scans in agentTasks table
@@ -95,23 +93,4 @@ func startWebServer(cfg *configv1.Config) {
 	if err := webServer.ListenAndServe(); err != nil {
 		log.Fatalln("Error starting web server", err)
 	}
-}
-
-func logConfig(cfg *configv1.Config) {
-	log.Println()
-	log.Println("- - - - Configuration - - - - -")
-	log.Printf("  API Server URL: %s\n", cfg.APIServerURL())
-	if cfg.Site.LogAPITokenOnStartup {
-		log.Printf("  API Token: %s\n", cfg.Site.APIToken)
-	}
-	log.Println("")
-	log.Printf("  Web Server URL: %s\n", cfg.WebServerURL())
-	log.Println("")
-	log.Printf("  Database Host: %s\n", cfg.Database.Host)
-	log.Printf("  Database Port: %d\n", cfg.Database.Port)
-	log.Printf("  Database User: %s\n", cfg.Database.User)
-	log.Printf("  Database Name: %s\n", cfg.Database.Name)
-	log.Printf("  Database Password: %s\n", strings.Repeat("*", len(cfg.Database.Password)))
-	log.Println("- - - - - - - - - - - - - - - -")
-	log.Println()
 }

--- a/docker-compose/dev.yaml
+++ b/docker-compose/dev.yaml
@@ -1,0 +1,45 @@
+services:
+  db:
+    image: postgres:17.2
+    container_name: postgresdb
+    networks:
+      - gokakashi-network
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: CHANGE_THIS_PASSWORD
+      POSTGRES_DB: gokakashi
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  gokakashi-server:
+    build: ../
+    container_name: gokakashi-server
+    command: server
+    networks:
+      - gokakashi-network
+    ports:
+      - "5555:5555"
+      - "5556:5556"
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: CHANGE_THIS_PASSWORD
+      DB_NAME: gokakashi
+    depends_on:
+      db:
+        condition: service_healthy
+
+networks:
+  gokakashi-network:
+
+volumes:
+  pgdata:
+  workspace:

--- a/internal/assigner/assigner.go
+++ b/internal/assigner/assigner.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/shinobistack/gokakashi/internal/restapi/v1/agents"
-	"github.com/shinobistack/gokakashi/internal/restapi/v1/agenttasks"
-	"github.com/shinobistack/gokakashi/internal/restapi/v1/scans"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/agents"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/agenttasks"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/scans"
 )
 
 // Assigns scanID to available Agents
@@ -37,7 +38,7 @@ func constructURL(server string, port int, path string) string {
 	return u.String()
 }
 
-func StartAssigner(server string, port int, token string, interval time.Duration) {
+func Start(server string, port int, token string, interval time.Duration) {
 	log.Println("Starting the periodic task assigner...")
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -45,7 +46,6 @@ func StartAssigner(server string, port int, token string, interval time.Duration
 	for range ticker.C {
 		AssignTasks(server, port, token)
 	}
-
 }
 
 func AssignTasks(server string, port int, token string) {

--- a/internal/config/v1/default.go
+++ b/internal/config/v1/default.go
@@ -1,0 +1,86 @@
+package v1
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func DefaultConfig() (*Config, error) {
+	apiToken := os.Getenv("GOKAKASHI_API_SERVER_TOKEN")
+	logAPITokenOnStartup := false
+	if apiToken == "" {
+		generatedToken, err := generateToken(32)
+		if err != nil {
+			return nil, fmt.Errorf("error generating an api token: %w", err)
+		}
+		apiToken = generatedToken
+		logAPITokenOnStartup = true
+	}
+
+	apiHost := os.Getenv("GOKAKASHI_API_SERVER_HOST")
+	apiPort, _ := strconv.Atoi(os.Getenv("GOKAKASHI_API_SERVER_PORT"))
+	if apiPort == 0 {
+		apiPort = 5556
+	}
+
+	webHost := os.Getenv("GOKAKASHI_WEB_SERVER_HOST")
+	webPort, _ := strconv.Atoi(os.Getenv("GOKAKASHI_WEB_SERVER_PORT"))
+	if webPort == 0 {
+		webPort = 5555
+	}
+
+	dbHost := os.Getenv("DB_HOST")
+	if dbHost == "" {
+		dbHost = "localhost"
+	}
+	dbPort, _ := strconv.Atoi(os.Getenv("DB_PORT"))
+	if dbPort == 0 {
+		dbPort = 5432
+	}
+	dbName := os.Getenv("DB_NAME")
+	if dbName == "" {
+		dbName = "postgres"
+	}
+	dbUser := os.Getenv("DB_USER")
+	if dbUser == "" {
+		dbUser = "postgres"
+	}
+	dbPassword := os.Getenv("DB_PASSWORD")
+	if dbPassword == "" {
+		dbPassword = "postgres"
+	}
+
+	return &Config{
+		Site: SiteConfig{
+			APIToken:             apiToken,
+			LogAPITokenOnStartup: logAPITokenOnStartup,
+			Host:                 apiHost,
+			Port:                 apiPort,
+		},
+		WebServer: WebServerConfig{
+			Host: webHost,
+			Port: webPort,
+		},
+		Database: DbConnection{
+			Host:     dbHost,
+			Port:     dbPort,
+			User:     dbUser,
+			Password: dbPassword,
+			Name:     dbName,
+		},
+	}, nil
+}
+
+func generateToken(length int) (string, error) {
+	token := make([]byte, length)
+
+	_, err := rand.Read(token)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(token), nil
+}

--- a/internal/config/v1/loader.go
+++ b/internal/config/v1/loader.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+func LoadConfig(configFile string) (*Config, error) {
+	config := &Config{}
+
+	yamlFile, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %v", err)
+	}
+
+	err = yaml.Unmarshal(yamlFile, config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing YAML file: %v", err)
+	}
+
+	return config, nil
+}
+
+// validateConfig validates the loaded configuration to ensure required fields are present
+func ValidateConfig(config *Config) error {
+	if config.Site.APIToken == "" {
+		return fmt.Errorf("API token is missing")
+	}
+
+	// ToDo: Minimum one integration must be provided and that needs to be ...?
+	if len(config.Integrations) == 0 {
+		return fmt.Errorf("at least one integration must be defined")
+	}
+	for _, integration := range config.Integrations {
+		if integration.Name == "" || integration.Type == "" {
+			return fmt.Errorf("Integration name and type are required")
+		}
+	}
+	for _, policy := range config.Policies {
+		if policy.Name == "" {
+			return fmt.Errorf("Policy name is required")
+		}
+		if policy.Image.Registry == "" || policy.Image.Name == "" {
+			return fmt.Errorf("Policy image registry and name are required")
+		}
+		if policy.Trigger.Type == "cron" && policy.Trigger.Schedule == "" {
+			return fmt.Errorf("Policy with cron trigger must define a schedule")
+		}
+		for _, notify := range policy.Notify {
+			if notify.To == "" {
+				return fmt.Errorf("Notify 'to' field is required")
+			}
+			if notify.When == "" {
+				return fmt.Errorf("Notify 'when' field is required")
+			}
+		}
+	}
+	return nil
+
+	// ToDo: more validations to be added as per config design
+	// ToDo: How do we validated the token string for each webserver, currently this is not being used
+}
+
+func LoadAndValidateConfig(configPath string) (*Config, error) {
+	// Load the YAML configuration
+	log.Printf("Loading configuration from YAML file: %s", configPath)
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Validate the configuration
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("configuration validation failed: %w", err)
+	}
+	log.Println("Configuration loaded and validated successfully.")
+	return cfg, nil
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -6,16 +6,17 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/shinobistack/gokakashi/internal/parser"
-	"github.com/shinobistack/gokakashi/internal/restapi/v1/integrations"
-	"github.com/shinobistack/gokakashi/internal/restapi/v1/scans"
-	"github.com/shinobistack/gokakashi/pkg/notifier/v1"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/shinobistack/gokakashi/internal/parser"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/integrations"
+	"github.com/shinobistack/gokakashi/internal/restapi/v1/scans"
+	"github.com/shinobistack/gokakashi/pkg/notifier/v1"
 )
 
 type HashEntry struct {
@@ -51,7 +52,7 @@ func constructURL(server string, port int, path string) string {
 	return u.String()
 }
 
-func StartScanNotifier(server string, port int, token string, interval time.Duration) {
+func Start(server string, port int, token string, interval time.Duration) {
 	log.Println("Starting the periodic notify execution...")
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()


### PR DESCRIPTION
Some notes on what we are doing here.

- `docker-compose/dev.yaml` boots up a vanila postgres and gokakashi server with default config
- We are stopping the handling of v0 config

It looks something like this now

```
gokakashi-server  | 2025/01/23 01:37:08 ==== Starting gokakashi ====
gokakashi-server  | 2025/01/23 01:37:08
gokakashi-server  | - - - - Configuration - - - - -
gokakashi-server  |   API Server URL: http://localhost:5556
gokakashi-server  |   API Token: <secure string>
gokakashi-server  |
gokakashi-server  |   Web Server URL: http://localhost:5555
gokakashi-server  |
gokakashi-server  |   Database Host: db
gokakashi-server  |   Database Port: 5432
gokakashi-server  |   Database User: postgres
gokakashi-server  |   Database Name: gokakashi
gokakashi-server  |   Database Password: ********************
gokakashi-server  | - - - - - - - - - - - - - - - -
gokakashi-server  |
gokakashi-server  | 2025/01/23 01:37:08 Database schema created successfully
gokakashi-server  | 2025/01/23 01:37:08 Populating database from configuration...
gokakashi-server  | 2025/01/23 01:37:08 Starting the periodic task assigner...
gokakashi-server  | 2025/01/23 01:37:08 Starting the periodic notify execution...
```