### PR TITLE
updates binary release workflow with option to provide tag input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: dist/*
-          title: "🚀 gokakashi ${{ github.event.inputs.title }}"
+          title: "🚀 ${{ github.event.inputs.title }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag for the release (e.g., v0.1.0)"
+        required: true
 
 jobs:
   build-and-release-binaries:
@@ -39,5 +43,6 @@ jobs:
       - name: Upload Release Binaries
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.event.inputs.tag }}
           files: dist/*
           body: "🚀 GoKakashi Agent Release - See Changelog for Details!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
           go-version: "1.23"
 
       - name: Tidy Up Go Modules
-          run: go mod tidy
+        run: go mod tidy
 
-      - name: Tidy Up Go Modules
-          run: npm install
+      - name: Install Dependencies (webapp)
+        run: npm install
 
       - name: Build Binaries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
       tag:
         description: "Tag for the release (e.g., v0.1.0)"
         required: true
-      header:
-        description: "One line description (e.g., v0.1.0 Chidori)"
+      title:
+        description: "Title for the release made (e.g., v0.1.0 Chidori)"
         required: false
 
 jobs:
@@ -48,4 +48,4 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: dist/*
-          body: "🚀 gokakashi - **${{ github.event.inputs.header }}**"
+          title: "🚀 gokakashi ${{ github.event.inputs.title }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Install Dependencies (webapp)
         run: npm install
+        working-directory: ./webapp
 
       - name: Build Binaries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release GoKakashi Agent
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build-and-release-binaries:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+
+      - name: Tidy Up Go Modules
+          run: go mod tidy
+
+      - name: Tidy Up Go Modules
+          run: npm install
+
+      - name: Build Binaries
+        run: |
+          mkdir -p dist
+          GOOS=linux GOARCH=amd64 go build -o dist/gokakashi-agent-linux-amd64 ./cmd/agent.go
+          GOOS=linux GOARCH=arm64 go build -o dist/gokakashi-agent-linux-arm64 ./cmd/agent.go
+          GOOS=darwin GOARCH=amd64 go build -o dist/gokakashi-agent-mac-amd64 ./cmd/agent.go
+          GOOS=darwin GOARCH=arm64 go build -o dist/gokakashi-agent-mac-arm64 ./cmd/agent.go
+          GOOS=windows GOARCH=amd64 go build -o dist/gokakashi-agent-windows-amd64.exe ./cmd/agent.go
+
+      - name: Upload Release Binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+          body: "🚀 GoKakashi Agent Release - See Changelog for Details!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         description: "Tag for the release (e.g., v0.1.0)"
         required: true
       title:
-        description: "Title for the release made (e.g., v0.1.0 Chidori)"
+        description: "Title for the release (e.g., v0.1.0 Chidori)"
         required: false
 
 jobs:
@@ -48,4 +48,5 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: dist/*
-          title: "🚀 ${{ github.event.inputs.title }}"
+          title: ${{ github.event.inputs.title }}
+          body: "🚀"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       tag:
         description: "Tag for the release (e.g., v0.1.0)"
         required: true
+      header:
+        description: "One line description (e.g., v0.1.0 Chidori)"
+        required: false
 
 jobs:
   build-and-release-binaries:
@@ -45,4 +48,4 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: dist/*
-          body: "🚀 GoKakashi Agent Release - See Changelog for Details!"
+          body: "🚀 gokakashi - **${{ github.event.inputs.header }}**"


### PR DESCRIPTION
This workflow gets triggered manually with inputs
- tag (required)
- title (not required)