### PR TITLE
feat: introduce api_host_url config option

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -67,10 +67,11 @@ func runServer(cmd *cobra.Command, args []string) {
 
 func startAPIServer(cfg *configv1.Config) {
 	s := &restapiv1.Server{
-		AuthToken: cfg.Site.APIToken,
-		Websites:  cfg.Site.Host,
-		Port:      cfg.Site.Port,
-		DBConfig:  cfg.Database,
+		AuthToken:          cfg.Site.APIToken,
+		Websites:           cfg.Site.Host,
+		Port:               cfg.Site.Port,
+		DBConfig:           cfg.Database,
+		CorsAllowedOrigins: append(cfg.Site.CorsAllowedOrigins, cfg.WebServerURL()),
 	}
 	go s.Serve()
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -77,7 +77,11 @@ func startAPIServer(cfg *configv1.Config) {
 }
 
 func startWebServer(cfg *configv1.Config) {
-	webServer, err := webapp.New(cfg.WebServerServingAddress(), cfg.WebServer.APIHostURL)
+	apiUrl := cfg.WebServer.APIHostURL
+	if apiUrl == "" {
+		apiUrl = cfg.APIServerURL()
+	}
+	webServer, err := webapp.New(cfg.WebServerServingAddress(), apiUrl)
 	if err != nil {
 		log.Fatalln("Error creating web server", err)
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -76,7 +76,7 @@ func startAPIServer(cfg *configv1.Config) {
 }
 
 func startWebServer(cfg *configv1.Config) {
-	webServer, err := webapp.New(cfg.WebServerServingAddress(), cfg.APIServerURL())
+	webServer, err := webapp.New(cfg.WebServerServingAddress(), cfg.WebServer.APIHostURL)
 	if err != nil {
 		log.Fatalln("Error creating web server", err)
 	}

--- a/internal/config/v1/config.go
+++ b/internal/config/v1/config.go
@@ -113,6 +113,7 @@ func (cfg *Config) String() string {
 	if cfg.Site.LogAPITokenOnStartup {
 		s.WriteString(fmt.Sprintf("  API Token: %s\n", cfg.Site.APIToken))
 	}
+	s.WriteString(fmt.Sprintf("  API Server CORS Allowed Origins: %s\n", strings.Join(cfg.Site.CorsAllowedOrigins, " ")))
 	s.WriteString("\n")
 	s.WriteString(fmt.Sprintf("  Web Server URL: %s\n", cfg.WebServerURL()))
 	s.WriteString("\n")

--- a/internal/config/v1/config.go
+++ b/internal/config/v1/config.go
@@ -25,6 +25,12 @@ type SiteConfig struct {
 type WebServerConfig struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
+
+	// APIHostURL denotes the API URL that will be used by
+	// the client side web app to call the API.
+	//
+	// This is often a friendly URL such as a custom domain name: https://api.gokakashi.example.com
+	APIHostURL string `yaml:"api_host_url"`
 }
 
 // Trigger specifies the action schedule (cron or CI-based)

--- a/internal/config/v1/config.go
+++ b/internal/config/v1/config.go
@@ -21,7 +21,7 @@ type SiteConfig struct {
 	Host                 string `yaml:"host"`
 	Port                 int    `yaml:"port"`
 
-	CorsAllowedOrigins []string `yaml:"cors_allowed_origins`
+	CorsAllowedOrigins []string `yaml:"cors_allowed_origins"`
 }
 
 type WebServerConfig struct {

--- a/internal/config/v1/config.go
+++ b/internal/config/v1/config.go
@@ -20,6 +20,8 @@ type SiteConfig struct {
 	LogAPITokenOnStartup bool   `yaml:"log_api_token_on_startup"`
 	Host                 string `yaml:"host"`
 	Port                 int    `yaml:"port"`
+
+	CorsAllowedOrigins []string `yaml:"cors_allowed_origins`
 }
 
 type WebServerConfig struct {

--- a/internal/restapi/v1/server.go
+++ b/internal/restapi/v1/server.go
@@ -119,9 +119,10 @@ func (srv *Server) Service() *web.Service {
 	apiV1.Delete("/scannotify/{scan_id}", usecase.NewInteractor(scannotify1.DeleteScanNotify(srv.DB)))
 
 	s.Use(cors.New(cors.Options{
-		AllowedOrigins: srv.CorsAllowedOrigins,
-		AllowedMethods: []string{http.MethodOptions, http.MethodGet},
-		AllowedHeaders: []string{"Content-Type", "Authorization"},
+		AllowedOrigins:   srv.CorsAllowedOrigins,
+		AllowedMethods:   []string{http.MethodOptions, http.MethodGet},
+		AllowCredentials: true,
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},
 	}).Handler)
 	s.Mount("/api/v1/openapi.json", specHandler(apiV1.OpenAPICollector.SpecSchema().(*openapi31.Spec)))
 	s.Mount("/api/v1", apiV1)

--- a/internal/restapi/v1/server.go
+++ b/internal/restapi/v1/server.go
@@ -34,11 +34,12 @@ import (
 )
 
 type Server struct {
-	AuthToken string
-	Websites  string
-	Port      int
-	DB        *ent.Client
-	DBConfig  configv1.DbConnection
+	AuthToken          string
+	Websites           string
+	Port               int
+	DB                 *ent.Client
+	DBConfig           configv1.DbConnection
+	CorsAllowedOrigins []string
 }
 
 func (srv *Server) Service() *web.Service {
@@ -118,7 +119,7 @@ func (srv *Server) Service() *web.Service {
 	apiV1.Delete("/scannotify/{scan_id}", usecase.NewInteractor(scannotify1.DeleteScanNotify(srv.DB)))
 
 	s.Use(cors.New(cors.Options{
-		AllowedOrigins: []string{"http://localhost:5555"},
+		AllowedOrigins: srv.CorsAllowedOrigins,
 		AllowedMethods: []string{http.MethodOptions, http.MethodGet},
 		AllowedHeaders: []string{"Content-Type", "Authorization"},
 	}).Handler)


### PR DESCRIPTION
Introduces two new options
- `api_host_url`
- `cors_allowed_origin`

> 	// APIHostURL denotes the API URL that will be used by
> 	// the client side web app to call the API.
> 	//
> 	// This is often a friendly URL such as a custom domain name: https://api.gokakashi.example.com