### PR TITLE
ci: upgrade golang-ci lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.62
           args: --timeout=10m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62
+          version: v1.64
           args: --timeout=10m


### PR DESCRIPTION
Noticing lint failure here: https://github.com/shinobistack/gokakashi/actions/runs/13471198061/job/37644924892?pr=156

Opening this PR fix it.