### PR TITLE
ci: fix gh pages deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,6 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
-        working-directory: ./website
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
To fix the failure in https://github.com/shinobistack/gokakashi/actions/runs/13481306856