### PR TITLE
feat: custom fingerprint via CEL expression for creating issues in ticketing systems

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -142,9 +142,10 @@ func handleNotifyAndScan(ctx context.Context, policy *policies.GetPolicyResponse
 			}
 
 			formattedNotifies = append(formattedNotifies, schema.Notify{
-				To:     notifyDetails.String(),
-				When:   notify.When,
-				Format: notify.Format,
+				To:          notifyDetails.String(),
+				When:        notify.When,
+				Format:      notify.Format,
+				Fingerprint: notify.Fingerprint,
 			})
 		}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -177,7 +177,7 @@ func PopulateDatabase(client *ent.Client, cfg *v1.Config) {
 						continue
 					}
 					scanCreate.SetNotify([]schema.Notify{
-						{To: notifyIntegration.String(), When: notify.When, Format: notify.Format},
+						{To: notifyIntegration.String(), When: notify.When, Format: notify.Format, Fingerprint: notify.Fingerprint},
 					})
 				}
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -114,10 +114,7 @@ func NotifyProcess(server string, port int, token string) {
 					return
 				}
 
-				// vulnerabilityEntries := ConvertVulnerabilities(filteredVulnerabilities)
-
 				// Generate a hash and check/save
-				// hash := GenerateHash(scan.Image, vulnerabilityEntries)
 				scanner, err := scanner.NewScanner(scan.Scanner)
 				if err != nil {
 					log.Printf("Notifier: Unsupported scanner tool: %s", scan.Scanner)

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -125,7 +125,6 @@ func NotifyProcess(server string, port int, token string) {
 				}
 				var hash string
 				if notify.Fingerprint != "" {
-					fmt.Sprintf("notify.Fingerprint:%v", notify.Fingerprint)
 					hash, err = scanner.GenerateFingerprint(scan.Image, scan.Report, notify.Fingerprint)
 					if err != nil {
 						log.Printf("Notifier: Error generating fingerprint using CEL: %v", err)

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -91,7 +91,6 @@ func NotifyProcess(server string, port int, token string) {
 				if err != nil {
 					log.Printf("Notifier: invalid UUID string: %v", err)
 				}
-				log.Println(parsedNotifyToUUID)
 
 				integration, err := fetchIntegrationDetails(server, port, token, parsedNotifyToUUID)
 				if err != nil {

--- a/pkg/scanner/v1/interface.go
+++ b/pkg/scanner/v1/interface.go
@@ -4,6 +4,6 @@ package scanner
 type Scanner interface {
 	Scan(image string, severityLevels []string) (string, error)
 	// ParseReport For CEL evaluation
-	ParseReport(reportPath []byte) (map[string]interface{}, error)
-	// GetExpectedFields for valid fields
+	ParseReport(reportData []byte) (map[string]interface{}, error)
+	GenerateFingerprint(image string, reportData []byte, celExpression string) (string, error)
 }

--- a/pkg/scanner/v1/trivy.go
+++ b/pkg/scanner/v1/trivy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/ext"
 	"log"
 	"os"
 	"os/exec"
@@ -80,6 +81,8 @@ func (t *TrivyScanner) GenerateFingerprint(image string, reportData []byte, celE
 		cel.Declarations(
 			decls.NewVar("report", decls.NewObjectType("google.protobuf.Struct")),
 		),
+		ext.Strings(), // Enables string functions (split, join)
+		ext.Lists(),   // Enables list functions (map, filter, flatMap)
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create CEL environment: %w", err)

--- a/pkg/scanner/v1/trivy.go
+++ b/pkg/scanner/v1/trivy.go
@@ -72,7 +72,6 @@ func (t *TrivyScanner) GenerateFingerprint(image string, reportData []byte, celE
 	if err != nil {
 		return "", fmt.Errorf("failed to parse report: %w", err)
 	}
-	// fmt.Printf("[DEBUG] Parsed Report: %+v\n", parsedReport)
 
 	fmt.Printf("[DEBUG] Evaluating CEL: %s\n", celExpression)
 
@@ -110,8 +109,6 @@ func (t *TrivyScanner) GenerateFingerprint(image string, reportData []byte, celE
 	if !ok {
 		return "", fmt.Errorf("unexpected fingerprint type: %T", out.Value())
 	}
-
-	fmt.Printf("[DEBUG] Generated Fingerprint: %v\n", fingerprint)
 
 	return fingerprint, nil
 }


### PR DESCRIPTION
closes https://github.com/shinobistack/gokakashi/issues/166
Example of CEL expression passed in `fingerprint` for Trivy JSON type
```
notify:
      - to: acme-linear
        when: |
          report.Results.exists(r, r.Vulnerabilities.exists(v, v.Severity == 'CRITICAL'|| v.Severity == 'HIGH'))
        fingerprint: |
          report.ArtifactName.split(":")[0] + "_" + 
          report.Results
              .map(r, r.Vulnerabilities)
              .flatten()
              .filter(v, has(v.FixedVersion) && v.FixedVersion != "" && v.VulnerabilityID != "" && (v.Severity == "CRITICAL" || v.Severity == "HIGH"))
              .map(v, v.Severity + "-" + v.VulnerabilityID)
              .join("_")
```
view on how fingerprint looks for above CEL expression:
```
[DEBUG] Generated Fingerprint: <image_name_no_tag>_HIGH-CVE-2024-3596_HIGH-CVE-2025-1094_HIGH-CVE-2024-12797_HIGH-CVE-2024-12797
```