### PR TITLE
ci: push docker images for main branch commits and PRs with labels 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Docker push for main branch commits is not happening currently. This attempts to fix it.

We can use `ci/push-all-image` label to enable pushes in PRs where needed.