### PR TITLE
api,ui: introduce pagination for scans

### DIFF
--- a/internal/restapi/v1/scans/get.go
+++ b/internal/restapi/v1/scans/get.go
@@ -27,8 +27,10 @@ type GetScanResponse struct {
 }
 
 type ListScanRequest struct {
-	Status string `query:"status"`
-	Name   string `query:"name"`
+	Status  string `query:"status"`
+	Name    string `query:"name"`
+	Page    int    `query:"page"`
+	PerPage int    `query:"per_page"`
 }
 
 type GetScanRequest struct {
@@ -43,6 +45,18 @@ func ListScans(client *ent.Client) func(ctx context.Context, req ListScanRequest
 		if req.Status != "" {
 			query = query.Where(scans.Status(req.Status))
 		}
+
+		// Pagination logic
+		page := req.Page
+		perPage := req.PerPage
+		if page < 1 {
+			page = 1
+		}
+		if perPage < 1 {
+			perPage = 100
+		}
+		offset := (page - 1) * perPage
+		query = query.Limit(perPage).Offset(offset)
 
 		scanResults, err := query.All(ctx)
 		if err != nil {

--- a/internal/restapi/v1/scans/get_test.go
+++ b/internal/restapi/v1/scans/get_test.go
@@ -43,7 +43,7 @@ func TestListScans_Valid(t *testing.T) {
 		SetIntegrationID(integrations.ID).
 		SaveX(context.Background())
 
-	req := scans.ListScanRequest{"", ""}
+	req := scans.ListScanRequest{Status: "", Name: "", Page: 1, PerPage: 100}
 	res := []scans.GetScanResponse{}
 	err := scans.ListScans(client)(context.Background(), req, &res)
 

--- a/webapp/src/components/scans/List.jsx
+++ b/webapp/src/components/scans/List.jsx
@@ -15,6 +15,10 @@ const ScansList = () => {
             Authorization: `Bearer ${localStorage.getItem("adminSecret")}`,
             "Content-Type": "application/json",
           },
+          params: {
+            per_page: 25,
+            page: 1,
+          },
         });
         setScansData(response.data);
       } catch (error) {


### PR DESCRIPTION
We will need to avoid loading all scans at the same time