### PR TITLE
feat: agent can send heartbeat and run forever now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.component=server
 
-      - name: Build and Push Server Docker image
+      - name: Build and push server Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
@@ -97,7 +97,7 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.component=notifier
 
-      - name: Build and push Notifier Docker image
+      - name: Build and push notifier Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
@@ -149,7 +149,7 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.component=assigner
 
-      - name: Build and push Assigner Docker image
+      - name: Build and push assigner Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
@@ -160,6 +160,58 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation for assigner
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'ci/push-all-images')) }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.REPO }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  agentmon:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=ref,event=branch,prefix=agentmon-
+            type=ref,event=pr,prefix=agentmon-
+            type=sha,prefix=agentmon-
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.component=agentmon
+
+      - name: Build and push agentmon Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: cmd/agentmon/Dockerfile
+          push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'ci/push-all-images')) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation for agentmon
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'ci/push-all-images')) }}
         uses: actions/attest-build-provenance@v1
         with:

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -84,7 +84,7 @@ var agentStartCmd = &cobra.Command{
 			if err != nil {
 				log.Fatalf("Failed to create gokakashi API client: %v", err)
 			}
-			if err := agent.New(gokakashiAPIClient).Start(); err != nil {
+			if err := agent.New(gokakashiAPIClient).Start(cmd.Context()); err != nil {
 				log.Fatalf("Failed to start agent: %v", err)
 			}
 			return

--- a/cmd/agentmon/Dockerfile
+++ b/cmd/agentmon/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.24.1-alpine3.21 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o agentmon ./cmd/agentmon/main.go
+
+FROM alpine:3.21
+
+WORKDIR /app
+
+COPY --from=builder /app/agentmon .
+
+CMD ["./agentmon"]

--- a/cmd/agentmon/main.go
+++ b/cmd/agentmon/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	_ "github.com/lib/pq" // or your DB driver
+	"github.com/shinobistack/gokakashi/ent"
+	"github.com/shinobistack/gokakashi/ent/v2agents"
+	agentstatus "github.com/shinobistack/gokakashi/internal/agent/status/v2"
+)
+
+type Service struct {
+	dbClient           *ent.Client
+	heartbeatThreshold time.Duration
+	monitoringInterval time.Duration
+}
+
+func main() {
+	dbHost := os.Getenv("DB_HOST")
+	if dbHost == "" {
+		dbHost = "localhost"
+	}
+	dbPort, _ := strconv.Atoi(os.Getenv("DB_PORT"))
+	if dbPort == 0 {
+		dbPort = 5432
+	}
+	dbName := os.Getenv("DB_NAME")
+	if dbName == "" {
+		dbName = "postgres"
+	}
+	dbUser := os.Getenv("DB_USER")
+	if dbUser == "" {
+		dbUser = "postgres"
+	}
+	dbPassword := os.Getenv("DB_PASSWORD")
+	if dbPassword == "" {
+		dbPassword = "postgres"
+	}
+
+	client, err := ent.Open("postgres", fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", dbUser, dbPassword, dbHost, dbPort, dbName))
+	if err != nil {
+		log.Fatalf("failed opening connection to db: %v", err)
+	}
+	defer client.Close()
+
+	service := &Service{
+		dbClient:           client,
+		heartbeatThreshold: 10 * time.Second,
+		monitoringInterval: 10 * time.Second,
+	}
+	service.start()
+}
+
+func (s *Service) start() {
+	log.Printf("Starting agent monitor, with monitoring interval:%s, heartbeat threshold:%s\n", s.monitoringInterval.String(), s.heartbeatThreshold.String())
+	ticker := time.NewTicker(s.monitoringInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		s.monitorAgentState(context.Background())
+	}
+}
+
+// monitorAgentState monitors the state of all agents that are
+// not in terminal state (Lost or Exited).
+//
+// It marks agents as connected or lost based on the last heartbeat time
+// of the agent.
+func (s *Service) monitorAgentState(ctx context.Context) {
+	agents, err := s.dbClient.V2Agents.
+		Query().
+		Where(
+			v2agents.StatusNEQ(string(agentstatus.Lost)),
+			v2agents.StatusNEQ(string(agentstatus.Exited)),
+		).
+		All(ctx)
+	if err != nil {
+		log.Printf("failed to query agents: %v\n", err)
+		return
+	}
+	if len(agents) > 0 {
+		log.Printf("Found %d agents to monitor\n", len(agents))
+	}
+
+	now := time.Now()
+	heartbeatThreshold := now.Add(-s.heartbeatThreshold)
+
+	// TODO: Use batch update in future
+	connected, lost := 0, 0
+	for _, agent := range agents {
+		switch {
+		case agent.LastHeartbeatAt.After(heartbeatThreshold) && agent.Status == string(agentstatus.Disconnected):
+			s.markAgentConnected(ctx, agent)
+			connected++
+		case agent.LastHeartbeatAt.Before(heartbeatThreshold) && agent.Status != string(agentstatus.Lost):
+			s.markAgentLost(ctx, agent)
+			lost++
+		}
+	}
+
+	if connected > 0 || lost > 0 {
+		log.Printf("Marked %d agents as connected and %d agents as lost\n", connected, lost)
+	}
+}
+
+// markAgentConnected marks an agent as connected
+func (s *Service) markAgentConnected(ctx context.Context, agent *ent.V2Agents) {
+	_, err := s.dbClient.V2Agents.UpdateOneID(agent.ID).
+		SetStatus(string(agentstatus.Connected)).
+		Save(ctx)
+	if err != nil {
+		log.Printf("failed to update agent %v to connected: %v\n", agent.ID, err)
+		return
+	}
+	log.Printf("Agent %v : %s -> connected\n", agent.ID, agent.Status)
+}
+
+// markAgentLost marks an agent as lost
+func (s *Service) markAgentLost(ctx context.Context, agent *ent.V2Agents) {
+	_, err := s.dbClient.V2Agents.UpdateOneID(agent.ID).
+		SetStatus(string(agentstatus.Lost)).
+		Save(ctx)
+	if err != nil {
+		log.Printf("failed to update agent %v to lost: %v\n", agent.ID, err)
+		return
+	}
+	log.Printf("Agent %v : %s -> lost\n", agent.ID, agent.Status)
+}

--- a/docker-compose/base.yaml
+++ b/docker-compose/base.yaml
@@ -71,6 +71,23 @@ services:
       gokakashi-server:
         condition: service_started
 
+  gokakashi-agentmon:
+    build:
+      context: ../
+      dockerfile: cmd/agentmon/Dockerfile
+    container_name: gokakashi-agentmon
+    networks:
+      - gokakashi-network
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: CHANGE_THIS_PASSWORD
+      DB_NAME: gokakashi
+    depends_on:
+      db:
+        condition: service_healthy
+
 networks:
   gokakashi-network:
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,32 +3,60 @@ package agent
 import (
 	"context"
 	"log"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/shinobistack/gokakashi/pkg/client"
 )
 
 type Agent struct {
-	client *client.Client
-
-	id uuid.UUID
+	client          *client.Client
+	id              uuid.UUID
+	heartbeatTicker *time.Ticker
+	done            chan struct{}
+	stopOnce        sync.Once
 }
 
 func New(client *client.Client) *Agent {
 	return &Agent{
-		client: client,
+		client:          client,
+		heartbeatTicker: time.NewTicker(10 * time.Second),
+		done:            make(chan struct{}),
 	}
 }
 
-func (a *Agent) Start() error {
+func (a *Agent) Start(ctx context.Context) error {
 	log.Println("Starting gokakashi agent")
-	regAgent, err := a.client.Agent.Register(context.Background(), nil)
+	regAgent, err := a.client.Agent.Register(ctx, nil)
 	if err != nil {
 		return err
 	}
 	a.id = regAgent.ID
-	log.Println("Agent registered successfully! Agent ID: ", a.id)
-	log.Println("Agent details: ", regAgent)
+	log.Println("Agent registered with ID:", regAgent.ID, "Status:", regAgent.Status)
 
+	go a.startHeartbeat(ctx)
+	<-a.done // Block until Stop is called
 	return nil
+}
+
+func (a *Agent) startHeartbeat(ctx context.Context) {
+	log.Println("Starting heartbeat for agent:", a.id)
+	for range a.heartbeatTicker.C {
+		hbResp, err := a.client.Agent.Heartbeat(ctx, &client.AgentHeartbeatRequest{ID: a.id})
+		if err != nil {
+			log.Println("Heartbeat error:", err)
+			continue
+		}
+
+		log.Println("Heartbeat sent. Status:", hbResp.Status, "LastHeartbeatAt:", hbResp.LastHeartbeatAt)
+	}
+}
+
+func (a *Agent) Stop() {
+	log.Println("Stopping gokakashi agent")
+	a.heartbeatTicker.Stop()
+	a.stopOnce.Do(func() {
+		close(a.done)
+	})
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shinobistack/gokakashi/pkg/client"
+)
+
+// --- Custom RoundTripper to intercept HTTP requests ---
+type fakeRoundTripper struct {
+	registerCalled  *bool
+	heartbeatCalled *bool
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path == "/api/v2/agents" {
+		*f.registerCalled = true
+		resp := http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}
+		return &resp, nil
+	}
+	if len(req.URL.Path) > 20 && req.URL.Path[len(req.URL.Path)-10:] == "/heartbeat" {
+		*f.heartbeatCalled = true
+		resp := http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+		}
+		return &resp, nil
+	}
+	resp := http.Response{
+		StatusCode: 404,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+	}
+	return &resp, nil
+}
+
+// --- Test New ---
+func TestNewAgent(t *testing.T) {
+	mc := &client.Client{}
+	a := New(mc)
+	if a.client != mc {
+		t.Errorf("expected client to be set")
+	}
+	if a.heartbeatTicker == nil {
+		t.Errorf("expected heartbeatTicker to be set")
+	}
+	if a.done == nil {
+		t.Errorf("expected done channel to be set")
+	}
+}
+
+// --- Test Start ---
+func TestAgentStartAndStop(t *testing.T) {
+	registerCalled := false
+	heartbeatCalled := false
+	fakeTransport := &fakeRoundTripper{
+		registerCalled:  &registerCalled,
+		heartbeatCalled: &heartbeatCalled,
+	}
+	httpClient := &http.Client{Transport: fakeTransport}
+	cli, err := client.New("http://localhost", httpClient)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	a := &Agent{
+		client:          cli,
+		heartbeatTicker: time.NewTicker(10 * time.Millisecond),
+		done:            make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := a.Start(ctx)
+		if err != nil {
+			t.Errorf("Start returned error: %v", err)
+		}
+	}()
+
+	// Wait for heartbeat to be called
+	time.Sleep(20 * time.Millisecond)
+	a.Stop()
+	wg.Wait()
+
+	if !registerCalled {
+		t.Errorf("expected Register to be called")
+	}
+	if !heartbeatCalled {
+		t.Errorf("expected Heartbeat to be called")
+	}
+}
+
+// --- Test Stop idempotency ---
+func TestAgentStopIdempotent(t *testing.T) {
+	mc := &client.Client{}
+	a := New(mc)
+	a.Stop()
+	// Should not panic or block if called again
+	a.Stop()
+}

--- a/internal/restapi/v1/server.go
+++ b/internal/restapi/v1/server.go
@@ -130,6 +130,7 @@ func (srv *Server) Service() *web.Service {
 	apiV1.Delete("/scannotify/{scan_id}", usecase.NewInteractor(scannotify1.DeleteScanNotify(srv.DB)))
 
 	apiV2.Post("/agents", usecase.NewInteractor(v2agents.Register(srv.DB)))
+	apiV2.Patch("/agents/{agent_id}/heartbeat", usecase.NewInteractor(v2agents.Heartbeat(srv.DB)))
 
 	s.Use(cors.New(cors.Options{
 		AllowedOrigins: []string{"http://localhost:5555"},

--- a/internal/restapi/v2/agents/heartbeat.go
+++ b/internal/restapi/v2/agents/heartbeat.go
@@ -1,0 +1,31 @@
+package agents
+
+import (
+	"context"
+	"time"
+
+	"github.com/shinobistack/gokakashi/ent"
+	agentstatus "github.com/shinobistack/gokakashi/internal/agent/status/v2"
+	"github.com/shinobistack/gokakashi/internal/restapi/v2/io"
+	"github.com/swaggest/usecase/status"
+)
+
+func Heartbeat(client *ent.Client) func(ctx context.Context, req io.AgentHeartbeatRequest, res *io.AgentHeartbeatResponse) error {
+	return func(ctx context.Context, req io.AgentHeartbeatRequest, res *io.AgentHeartbeatResponse) error {
+		agent, err := client.V2Agents.UpdateOneID(req.ID).
+			SetLastHeartbeatAt(time.Now()).
+			Save(ctx)
+		if err != nil {
+			return status.Wrap(err, status.Internal)
+		}
+
+		*res = io.AgentHeartbeatResponse{
+			ID:              agent.ID,
+			Status:          agentstatus.Status(agent.Status),
+			LastHeartbeatAt: agent.LastHeartbeatAt,
+			CreatedAt:       agent.CreatedAt,
+			UpdatedAt:       agent.UpdatedAt,
+		}
+		return nil
+	}
+}

--- a/internal/restapi/v2/agents/heartbeat_test.go
+++ b/internal/restapi/v2/agents/heartbeat_test.go
@@ -1,0 +1,42 @@
+package agents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shinobistack/gokakashi/ent/enttest"
+	"github.com/shinobistack/gokakashi/internal/restapi/v2/io"
+	agentstatus "github.com/shinobistack/gokakashi/internal/agent/status/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeartbeat(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:heartbeat_test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	// Create an agent with initial status and old heartbeat
+	agent, err := client.V2Agents.Create().
+		SetStatus(string(agentstatus.Disconnected)).
+		SetLastHeartbeatAt(time.Now().Add(-1 * time.Hour)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	req := io.AgentHeartbeatRequest{
+		ID: agent.ID,
+	}
+	var res io.AgentHeartbeatResponse
+
+	err = Heartbeat(client)(ctx, req, &res)
+	require.NoError(t, err)
+
+	// Fetch the updated agent from DB
+	agentCheck, err := client.V2Agents.Get(ctx, agent.ID)
+	require.NoError(t, err)
+
+	require.WithinDuration(t, time.Now(), agentCheck.LastHeartbeatAt, 2*time.Second)
+	require.Equal(t, string(agentstatus.Disconnected), agentCheck.Status) // Status should not change
+	require.Equal(t, agent.ID, res.ID)
+	require.WithinDuration(t, agentCheck.LastHeartbeatAt, res.LastHeartbeatAt, time.Second)
+}

--- a/internal/restapi/v2/io/io.go
+++ b/internal/restapi/v2/io/io.go
@@ -19,3 +19,15 @@ type AgentRegisterResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
+
+type AgentHeartbeatRequest struct {
+	ID uuid.UUID `path:"agent_id"`
+}
+
+type AgentHeartbeatResponse struct {
+	ID              uuid.UUID    `json:"id"`
+	Status          agent.Status `json:"status"`
+	LastHeartbeatAt time.Time    `json:"last_heartbeat_at"`
+	CreatedAt       time.Time    `json:"created_at"`
+	UpdatedAt       time.Time    `json:"updated_at"`
+}

--- a/pkg/client/agent.go
+++ b/pkg/client/agent.go
@@ -11,6 +11,9 @@ type AgentService service
 type AgentRegisterRequest io.AgentRegisterRequest
 type AgentRegisterResponse io.AgentRegisterResponse
 
+type AgentHeartbeatRequest io.AgentHeartbeatRequest
+type AgentHeartbeatResponse io.AgentHeartbeatResponse
+
 func (s *AgentService) Register(ctx context.Context, _ *AgentRegisterRequest) (*AgentRegisterResponse, error) {
 	req, err := s.client.NewRequest("POST", "api/v2/agents", nil)
 	if err != nil {
@@ -22,5 +25,19 @@ func (s *AgentService) Register(ctx context.Context, _ *AgentRegisterRequest) (*
 		return nil, err
 	}
 
+	return &resp, nil
+}
+
+// Heartbeat sends a heartbeat for the agent with the given ID.
+func (s *AgentService) Heartbeat(ctx context.Context, reqData *AgentHeartbeatRequest) (*AgentHeartbeatResponse, error) {
+	req, err := s.client.NewRequest("PATCH", "api/v2/agents/"+reqData.ID.String()+"/heartbeat", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp AgentHeartbeatResponse
+	if err := s.client.Do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
 	return &resp, nil
 }


### PR DESCRIPTION
This introduces
- heartbeat API for agents
- `agentmon` service
  - This monitors the agents and maintains the state of them based on the heartbeat
  - We will be extending this to schedule tasks too
- agent to call the heartbeat API